### PR TITLE
OCM-2369 | feat: Github Action for checking commit format

### DIFF
--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -1,0 +1,38 @@
+# following the contribution guide this check enforces the commit format
+# [JIRA-TICKET] | [TYPE] : <MESSAGE>
+name: 'Validate Commit Messages'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  parse-commit-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Validate Commit Message(s)
+        run: |
+          IFS=$'\n' commit_messages=($(git log --pretty=format:"%s" HEAD...${{ github.event.pull_request.base.sha }}))          
+          
+          for message in "${commit_messages[@]}"
+          do
+          echo "validating $message"
+          if ! echo "$message" | grep -qE "^[A-Z]+-[0-9]+ \| (feat|fix|docs|style|refactor|test|chore|build|ci|perf) : .*$"; then
+            echo "Invalid commit message format. Expected format: JIRA_TICKET | TYPE : MESSAGE"
+            exit 1
+          fi
+          done


### PR DESCRIPTION
JIRA:[ OCM-2369](https://issues.redhat.com/browse/OCM-2369)

This story is about adding CI to this repo to help with development. This specific MR is about adding a check for commit message format.
