### PR TITLE
OCM-5397 | adding max byte size back

### DIFF
--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -1,0 +1,5 @@
+package utils
+
+const (
+	MaxByteSize = 64
+)


### PR DESCRIPTION
Related issue: OCM-5397

Because this is used as multiple values and I mistakenly thought it was only used for the length of an AWS IAM role