### PR TITLE
OCM-7481 | test: package addtional security groups preparation func and add vpc test suite

### DIFF
--- a/pkg/aws/aws_client/vpc.go
+++ b/pkg/aws/aws_client/vpc.go
@@ -91,7 +91,7 @@ func (client *AWSClient) ModifyVpcDnsAttribute(vpcID string, dnsAttribute string
 		log.LogError("Modify vpc dns attribute failed " + err.Error())
 		return nil, err
 	}
-	log.LogInfo("Modify vpc dns attribute success" + vpcID + dnsAttribute)
+	log.LogInfo("Modify vpc dns attribute %s success for %s", dnsAttribute, vpcID)
 	return resp, err
 }
 

--- a/pkg/aws/consts/consts.go
+++ b/pkg/aws/consts/consts.go
@@ -41,9 +41,10 @@ const (
 	TCPProtocol = "tcp"
 	UDPProtocol = "udp"
 
-	ProxySecurityGroupName        = "proxy-sg"
-	AdditionalSecurityGroupName   = "ocm-additional-sg"
-	ProxySecurityGroupDescription = "security group for proxy"
+	ProxySecurityGroupName                    = "proxy-sg"
+	AdditionalSecurityGroupName               = "ocm-additional-sg"
+	ProxySecurityGroupDescription             = "security group for proxy"
+	DefaultAdditionalSecurityGroupDescription = "This security group is created for OCM testing"
 
 	QEFlagKey = "ocm_ci_flag"
 

--- a/pkg/test/vpc_client/vpc.go
+++ b/pkg/test/vpc_client/vpc.go
@@ -153,8 +153,13 @@ func PrepareVPC(vpcName string, region string, vpcCIDR string, checkExisting boo
 	if vpcCIDR == "" {
 		vpcCIDR = CON.DefaultVPCCIDR
 	}
-	log.LogInfo("Going to prepare a vpc with name %s, on region %s, with cidr %s and subnets on zones %s",
+	logMessage := fmt.Sprintf("Going to prepare a vpc with name %s, on region %s, with cidr %s and subnets on zones %s",
 		vpcName, region, vpcCIDR, strings.Join(zones, ","))
+	if len(zones) == 0 {
+		logMessage = fmt.Sprintf("Going to prepare a vpc with name %s, on region %s, with cidr %s ",
+			vpcName, region, vpcCIDR)
+	}
+	log.LogInfo(logMessage)
 	awsclient, err := aws_client.CreateAWSClient("", region)
 	if err != nil {
 		log.LogError("Create AWS Client due to error: %s", err.Error())


### PR DESCRIPTION
```
lixue@Xue-Lis-MacBook-Pro ocm-common % ginkgo pkg/test/vpc_client
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.13.2
  Mismatched package versions found:
    2.17.1 used by vpc_client

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.
  
Running Suite: Account Roles Suite - /Users/lixue/Workspace/ocm-common/pkg/test/vpc_client
==========================================================================================
Random Seed: 1713428193

Will run 1 of 1 specs
time="2024-04-18 16:16:35" level=info msg="Going to prepare a vpc with name ocm-common-test, on region us-east-2, with cidr 10.0.0.0/16 "
time="2024-04-18 16:16:36" level=info msg="Going to create vpc and the follow resources on zones: "
time="2024-04-18 16:16:38" level=info msg="Create vpc success vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:38" level=info msg="Tag resource vpc-0b8a8a7d513584894 successfully"
time="2024-04-18 16:16:38" level=info msg="Created vpc with ID vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:38" level=info msg="VPC created on AWS with id: vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:39" level=info msg="Modify vpc dns attribute DnsHostnames success for vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:39" level=info msg="VPC DNS Updated on AWS with id: vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:39" level=info msg="Create igw success: igw-0e1be7227900549ef"
time="2024-04-18 16:16:40" level=info msg="Attach igw success: igw-0e1be7227900549ef"
time="2024-04-18 16:16:40" level=info msg="Prepare vpc internetgateway for vpc vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:40" level=info msg="Create subnets successfully"
time="2024-04-18 16:16:40" level=info msg="Create vpc chain successfully. Enjoy it."
time="2024-04-18 16:16:40" level=info msg="Create security group sg-0c4f3390e2ea4614b success for vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:41" level=info msg="Tag resource sg-0c4f3390e2ea4614b successfully"
time="2024-04-18 16:16:41" level=info msg="Created tagged security group with ID sg-0c4f3390e2ea4614b"
time="2024-04-18 16:16:41" level=info msg="Authorize security group success sg-0c4f3390e2ea4614b"
time="2024-04-18 16:16:42" level=info msg="Authorize security group success sg-0c4f3390e2ea4614b"
time="2024-04-18 16:16:42" level=info msg="Create security group sg-07e8f85532758308b success for vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:43" level=info msg="Tag resource sg-07e8f85532758308b successfully"
time="2024-04-18 16:16:43" level=info msg="Created tagged security group with ID sg-07e8f85532758308b"
time="2024-04-18 16:16:43" level=info msg="Authorize security group success sg-07e8f85532758308b"
time="2024-04-18 16:16:43" level=info msg="Authorize security group success sg-07e8f85532758308b"
time="2024-04-18 16:16:44" level=info msg="Create security group sg-04891490e7a407c92 success for vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:45" level=info msg="Tag resource sg-04891490e7a407c92 successfully"
time="2024-04-18 16:16:45" level=info msg="Created tagged security group with ID sg-04891490e7a407c92"
time="2024-04-18 16:16:45" level=info msg="Authorize security group success sg-04891490e7a407c92"
time="2024-04-18 16:16:45" level=info msg="Authorize security group success sg-04891490e7a407c92"
time="2024-04-18 16:16:45" level=info msg="Going to delete the vpc and follow resources by ID: vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:45" level=info msg="Going to terminate proxy instances if existing"
time="2024-04-18 16:16:46" level=info msg="Got no instances to terminate."
time="2024-04-18 16:16:46" level=info msg="Terminating instances  successfully"
time="2024-04-18 16:16:46" level=info msg="Delete vpc instances successfully"
time="2024-04-18 16:16:46" level=info msg="Going to delete proxy security group"
time="2024-04-18 16:16:47" level=info msg="Release rules successfully for SG sg-04891490e7a407c92"
time="2024-04-18 16:16:48" level=info msg="Delete security group sg-04891490e7a407c92 success "
time="2024-04-18 16:16:49" level=info msg="Release rules successfully for SG sg-07e8f85532758308b"
time="2024-04-18 16:16:49" level=info msg="Delete security group sg-07e8f85532758308b success "
time="2024-04-18 16:16:50" level=info msg="Release rules successfully for SG sg-0c4f3390e2ea4614b"
time="2024-04-18 16:16:51" level=info msg="Delete security group sg-0c4f3390e2ea4614b success "
time="2024-04-18 16:16:51" level=info msg="Delete vpc vpc proxy security group successfully"
time="2024-04-18 16:16:51" level=info msg="Got main association for rt rtb-0efa776f46320280f"
time="2024-04-18 16:16:51" level=info msg="Delete vpc route tables successfully"
time="2024-04-18 16:16:51" level=info msg="Delete vpc nat gateways successfully"
time="2024-04-18 16:16:51" level=info msg="Got total clean set, going to delete other possible resource leak"
time="2024-04-18 16:16:57" level=info msg="Detach igw igw-0e1be7227900549ef success from vpc vpc-0b8a8a7d513584894"
time="2024-04-18 16:16:57" level=info msg="Delete igw success: igw-0e1be7227900549ef"
time="2024-04-18 16:16:58" level=info msg="Delete vpc success vpc-0b8a8a7d513584894"
•

Ran 1 of 1 Specs in 22.893 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 25.248685382s
Test Suite Passed
```