### PR TITLE
OCM-11113 | feat: drop min disk size for nodepools to 75GiB

### DIFF
--- a/pkg/machinepool/validations/disk_size.go
+++ b/pkg/machinepool/validations/disk_size.go
@@ -18,7 +18,7 @@ const (
 	// 16 TiB - limit as of 4.14
 	machinePoolRootVolumeSizeMaxAsOf414 = 16384
 	// constants for node pool root size validation
-	nodePoolRootAWSVolumeSizeMin = 128
+	nodePoolRootAWSVolumeSizeMin = 75
 	nodePoolRootAWSVolumeSizeMax = 16384
 )
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-11113