### PR TITLE
OCM-13377 | fix: Add support for GovCloud and other AWS partitions

### DIFF
--- a/pkg/aws/aws_client/client.go
+++ b/pkg/aws/aws_client/client.go
@@ -3,6 +3,7 @@ package aws_client
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -113,6 +114,22 @@ func (client *AWSClient) GetAWSAccountID() string {
 		return ""
 	}
 	return *out.Account
+}
+
+func (client *AWSClient) GetAWSPartition() string {
+	defaultPartition := "aws"
+	input := &sts.GetCallerIdentityInput{}
+	out, err := client.StsClient.GetCallerIdentity(client.ClientContext, input)
+	if err != nil {
+		// Failed to get caller identity, return default partition
+		return defaultPartition
+	}
+	segments := strings.Split(*out.Arn, ":")
+	if len(segments) < 2 {
+		// Failed to parse ARN, return default partition
+		return defaultPartition
+	}
+	return segments[1]
 }
 
 func (client *AWSClient) EC2() *ec2.Client {

--- a/pkg/test/kms_key/kms.go
+++ b/pkg/test/kms_key/kms.go
@@ -14,7 +14,7 @@ func CreateOCMTestKMSKey(region string, multiRegion bool, testClient string) (st
 	if err != nil {
 		return "", err
 	}
-	accountRoleArns := []string{fmt.Sprintf("arn:aws:iam::%s:root", client.AccountID)}
+	accountRoleArns := []string{fmt.Sprintf("arn:%s:iam::%s:root", client.GetAWSPartition(), client.AccountID)}
 	testKMSKeyPolicy := KMSKeyPolicy{
 		Statement: []Statement{
 			{


### PR DESCRIPTION
Adds a function to the AWS client to get the current AWS partition, and fixes the `CreateOCMTestKMSKey` function when running against a GovCloud account