### PR TITLE
Return error on failed EIP allocation

### DIFF
--- a/pkg/aws/aws_client/eip.go
+++ b/pkg/aws/aws_client/eip.go
@@ -48,6 +48,7 @@ func (client *AWSClient) AllocateEIPAndAssociateInstance(instanceID string) (str
 	allocRes, err := client.AllocateEIPAddress()
 	if err != nil {
 		log.LogError("Failed allocated EIP: %s", err)
+		return "", err
 	} else {
 		log.LogInfo("Successfully allocated EIP: %s", *allocRes.PublicIp)
 	}


### PR DESCRIPTION
Returns an error when failing to allocate an EIP address. This prevents a nil-pointer error below when trying to use the allocated address to associate an address within the EC2 client.