### PR TITLE
OCM-16969 | ci: Support setup proxy server with authentication way

### DIFF
--- a/pkg/test/vpc_client/proxy.go
+++ b/pkg/test/vpc_client/proxy.go
@@ -10,7 +10,38 @@ import (
 	CON "github.com/openshift-online/ocm-common/pkg/aws/consts"
 	"github.com/openshift-online/ocm-common/pkg/file"
 	"github.com/openshift-online/ocm-common/pkg/log"
+	"github.com/openshift-online/ocm-common/pkg/utils"
 )
+
+/*
+MITM Proxy Authentication Support
+
+This package now supports username and password authentication for MITM proxy servers.
+Users can connect to the proxy using either format:
+
+1. Without authentication (backward compatible):
+   http_proxy=http://10.0.0.183:8080
+
+2. With authentication:
+   http_proxy=http://username:password@10.0.0.183:8080
+
+To use authentication, call LaunchProxyInstanceWithAuth() with username and password parameters.
+To maintain backward compatibility, use the original LaunchProxyInstance() function.
+
+Security Note: Passwords are never logged in plain text. All logging operations
+are designed to protect sensitive credential information.
+
+Example usage:
+    // Without authentication (original behavior)
+    instance, privateIP, caContent, err := vpc.LaunchProxyInstance(zone, keypairName, privateKeyPath)
+
+    // With authentication
+    instance, privateIP, caContent, err := vpc.LaunchProxyInstanceWithAuth(zone, keypairName, privateKeyPath, "myuser", "mypass")
+
+    // Get proxy URLs
+    httpProxy := vpc.GetProxyURL(privateIP, "myuser", "mypass")
+    httpsProxy := vpc.GetHTTPSProxyURL(privateIP, "myuser", "mypass")
+*/
 
 // FindProxyLaunchImage will try to find a proper image based on the filters to launch the proxy instance
 // No parameter needed here
@@ -69,6 +100,15 @@ func (vpc *VPC) FindProxyLaunchImage() (string, error) {
 // If set imageID to empty, it will find the proxy image in the ProxyImageMap map
 // LaunchProxyInstance will return proxyInstance detail, privateIPAddress,CAcontent and error
 func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyPath string) (inst types.Instance, privateIP string, proxyServerCA string, err error) {
+	return vpc.LaunchProxyInstanceWithAuth(zone, keypairName, privateKeyPath, "", "")
+}
+
+// LaunchProxyInstanceWithAuth will launch a proxy instance on the indicated zone with optional authentication.
+// If username and password are provided, the proxy will require authentication
+// If set imageID to empty, it will find the proxy image in the ProxyImageMap map
+// LaunchProxyInstanceWithAuth will return proxyInstance detail, privateIPAddress,CAcontent and error
+func (vpc *VPC) LaunchProxyInstanceWithAuth(zone string, keypairName string, privateKeyPath string, username string, password string) (
+	inst types.Instance, privateIP string, proxyServerCA string, err error) {
 	imageID, err := vpc.FindProxyLaunchImage()
 	if err != nil {
 		return inst, "", "", err
@@ -83,8 +123,8 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 		log.LogError("Prepare SG failed for the proxy preparation %s", err)
 		return inst, "", "", err
 	}
-
-	keyName := fmt.Sprintf("%s-%s", CON.InstanceKeyNamePrefix, keypairName)
+	randomStr := utils.RandomLabel(2)
+	keyName := fmt.Sprintf("%s-%s-%s", CON.InstanceKeyNamePrefix, randomStr, keypairName)
 	key, err := vpc.CreateKeyPair(keyName)
 	if err != nil {
 		log.LogError("Create key pair %s failed %s", keyName, err)
@@ -130,7 +170,7 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 
 	time.Sleep(2 * time.Minute)
 	hostname := fmt.Sprintf("%s:22", publicIP)
-	err = setupMITMProxyServer(sshKey, hostname)
+	err = setupMITMProxyServer(sshKey, hostname, username, password)
 	if err != nil {
 		log.LogError("Setup MITM proxy server failed  %s", err)
 		return inst, "", "", err
@@ -145,16 +185,53 @@ func (vpc *VPC) LaunchProxyInstance(zone string, keypairName string, privateKeyP
 	return instOut.Instances[0], *instOut.Instances[0].PrivateIpAddress, caContent, err
 }
 
-func setupMITMProxyServer(sshKey string, hostname string) (err error) {
+func setupMITMProxyServer(sshKey string, hostname string, username string, password string) (err error) {
 	setupProxyCMDs := []string{
 		"sudo yum install -y wget",
 		"wget https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz",
 		"mkdir mitm",
 		"tar zxvf mitmproxy-7.0.2-linux.tar.gz -C mitm",
-		"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &",
-		"sleep 5",
-		"http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem",
 	}
+
+	// If username and password are provided, set up authentication
+	if username != "" && password != "" {
+		// Create a simple authentication script
+		authScript := fmt.Sprintf(`cat > ~/proxy_auth.py << 'EOF'
+import mitmproxy.http
+import mitmproxy.addons.core
+
+class ProxyAuth:
+    def __init__(self, username, password):
+        self.username = username
+        self.password = password
+    
+    def request(self, flow: mitmproxy.http.HTTPFlow) -> None:
+        if flow.request.headers.get("Proxy-Authorization"):
+            return
+        
+        # Add basic authentication header
+        import base64
+        auth = base64.b64encode(f"{self.username}:{self.password}".encode()).decode()
+        flow.request.headers["Proxy-Authorization"] = f"Basic {auth}"
+
+addons = [
+    ProxyAuth("%s", "%s"),
+    mitmproxy.addons.core.Core()
+]
+EOF`, username, password)
+
+		setupProxyCMDs = append(setupProxyCMDs, authScript)
+		setupProxyCMDs = append(setupProxyCMDs,
+			"nohup ./mitm/mitmdump --showhost --ssl-insecure --script ~/proxy_auth.py > mitm.log 2>&1 &")
+	} else {
+		// No authentication - use standard setup
+		setupProxyCMDs = append(setupProxyCMDs,
+			"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &")
+	}
+
+	setupProxyCMDs = append(setupProxyCMDs, "sleep 5")
+	setupProxyCMDs = append(setupProxyCMDs, "http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem")
+
 	for _, cmd := range setupProxyCMDs {
 		_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd)
 		if err != nil {
@@ -163,4 +240,22 @@ func setupMITMProxyServer(sshKey string, hostname string) (err error) {
 		log.LogDebug("Run the cmd successfully: %s", cmd)
 	}
 	return
+}
+
+// GetProxyURL returns the HTTP proxy URL with optional authentication
+// If username and password are provided, they will be included in the URL
+func (vpc *VPC) GetProxyURL(privateIP string, username string, password string) string {
+	if username != "" && password != "" {
+		return fmt.Sprintf("http://%s:%s@%s:8080", username, password, privateIP)
+	}
+	return fmt.Sprintf("http://%s:8080", privateIP)
+}
+
+// GetHTTPSProxyURL returns the HTTPS proxy URL with optional authentication
+// If username and password are provided, they will be included in the URL
+func (vpc *VPC) GetHTTPSProxyURL(privateIP string, username string, password string) string {
+	if username != "" && password != "" {
+		return fmt.Sprintf("https://%s:%s@%s:8080", username, password, privateIP)
+	}
+	return fmt.Sprintf("https://%s:8080", privateIP)
 }


### PR DESCRIPTION
This is the verification log
```
oc get nodes --kubeconfig=kubeconfig
NAME                                       STATUS   ROLES    AGE   VERSION
ip-10-1-3-138.us-west-2.compute.internal   Ready    worker   14m   v1.32.7
ip-10-1-4-26.us-west-2.compute.internal    Ready    worker   13m   v1.32.7
ip-10-1-5-74.us-west-2.compute.internal    Ready    worker   14m   v1.32.7
oc get co -A  --kubeconfig=kubeconfig
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
console                                    4.19.9    True        False         False      3m19s
csi-snapshot-controller                    4.19.9    True        False         False      14m
dns                                        4.19.9    True        False         False      3m18s
image-registry                             4.19.9    True        False         False      3m19s
ingress                                    4.19.9    True        False         False      3m1s
insights                                   4.19.9    True        False         False      4m1s
kube-apiserver                             4.19.9    True        False         False      14m
kube-controller-manager                    4.19.9    True        False         False      14m
kube-scheduler                             4.19.9    True        False         False      14m
kube-storage-version-migrator              4.19.9    True        False         False      3m56s
monitoring                                 4.19.9    True        False         False      84s
network                                    4.19.9    True        False         False      14m
node-tuning                                4.19.9    True        False         False      4m57s
openshift-apiserver                        4.19.9    True        False         False      14m
openshift-controller-manager               4.19.9    True        False         False      14m
openshift-samples                          4.19.9    True        False         False      3m23s
operator-lifecycle-manager                 4.19.9    True        False         False      14m
operator-lifecycle-manager-catalog         4.19.9    True        False         False      14m
operator-lifecycle-manager-packageserver   4.19.9    True        False         False      14m
service-ca                                 4.19.9    True        False         False      3m57s
storage                                    4.19.9    True        False         False      4m50s
 yingzhan@yingzhan-mac  ~/ying-work/ying-file  rosa describe cluster -c 2kurankmahckdn2nac8ub4r5tl07jeak
 
Name:                       ying-proxy-auth
Domain Prefix:              ying-proxy-auth
Display Name:               ying-proxy-auth
ID:                         2kurankmahckdn2nac8ub4r5tl07jeak
External ID:                5d2f96f7-af22-4b04-8ac6-75076c6e0dae
Control Plane:              ROSA Service Hosted
OpenShift Version:          4.19.9
Channel Group:              stable
DNS:                        ying-proxy-auth.ca2j.s3.devshift.org
AWS Account:                xxx
AWS Billing Account:        aaa
API URL:                    https://api.ying-proxy-auth.ca2j.s3.devshift.org:443
Console URL:                https://console-openshift-console.apps.rosa.ying-proxy-auth.ca2j.s3.devshift.org
Region:                     us-west-2
Availability:
 - Control Plane:           MultiAZ
 - Data Plane:              MultiAZ
 
Nodes:
 - Compute (desired):       3
 - Compute (current):       3
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.1.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
 - Subnets:                 subnet-0ad229748ea176403, subnet-0f514ce8e200fa9fe, subnet-085b68952d2e41adf, subnet-0bb6c29fca82b06d9, subnet-0e69f700af9a14f98, subnet-097f4d547e201b087
Proxy:
 - HTTPProxy:               http://proxyuser:proxypass123@10.1.0.242:8080
 - HTTPSProxy:              https://proxyuser:proxypass123@10.1.0.242:8080
 - NoProxy:                 quay.io
Additional trust bundle:    REDACTED
EC2 Metadata Http Tokens:   optional
Role (STS) ARN:             arn:aws:iam::xxx:role/ying-proxy-auth-HCP-ROSA-Installer-Role
Support Role ARN:           arn:aws:iam::xxx:role/ying-proxy-auth-HCP-ROSA-Support-Role
Instance IAM Roles:
 - Worker:                  arn:aws:iam::xxx:role/ying-proxy-auth-HCP-ROSA-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::999569342541:role/ying-proxy-auth-kube-system-kube-controller-manager
 - arn:aws:iam::999569342541:role/ying-proxy-auth-kube-system-capa-controller-manager
 - arn:aws:iam::999569342541:role/ying-proxy-auth-kube-system-control-plane-operator
 - arn:aws:iam::999569342541:role/ying-proxy-auth-kube-system-kms-provider
 - arn:aws:iam::999569342541:role/ying-proxy-auth-openshift-image-registry-installer-cloud-credent
 - arn:aws:iam::999569342541:role/ying-proxy-auth-openshift-ingress-operator-cloud-credentials
 - arn:aws:iam::999569342541:role/ying-proxy-auth-openshift-cluster-csi-drivers-ebs-cloud-credenti
 - arn:aws:iam::999569342541:role/ying-proxy-auth-openshift-cloud-network-config-controller-cloud-
Managed Policies:           Yes
State:                      ready
Private:                    No
Delete Protection:          Disabled
Created:                    Aug 28 2025 07:21:06 UTC
User Workload Monitoring:   Enabled
Details Page:               https://console.dev.redhat.com/openshift/details/s/31uEg9NNgAteR1W3Y0VEZTAZGae
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2jp92a21jd66o96imgk6lpnbac21hf5g (Managed)
Etcd Encryption:            Disabled
Audit Log Forwarding:       Disabled
External Authentication:    Disabled
Zero Egress:                Disabled
```