### PR TITLE
OCM-18472 | fix: Fix the issue of Jenkins on demand job fetch credential file path.

### DIFF
--- a/pkg/aws/aws_client/client.go
+++ b/pkg/aws/aws_client/client.go
@@ -51,12 +51,24 @@ func CreateAWSClient(profileName string, region string, awsSharedCredentialFile 
 	var err error
 
 	if len(awsSharedCredentialFile) > 0 {
-		file := awsSharedCredentialFile[0]
-		log.LogInfo("Got aws shared credential file path: %s ", file)
-		cfg, err = config.LoadDefaultConfig(context.TODO(),
-			config.WithRegion(region),
-			config.WithSharedCredentialsFiles([]string{file}),
-		)
+		if envSharedVPCCredential() {
+			log.LogInfo("Got AWS_SHARED_VPC_ACCESS_KEY_ID env settings, going to build the config with the env")
+			cfg, err = config.LoadDefaultConfig(context.TODO(),
+				config.WithRegion(region),
+				config.WithCredentialsProvider(
+					credentials.NewStaticCredentialsProvider(
+						os.Getenv("AWS_SHARED_VPC_ACCESS_KEY_ID"),
+						os.Getenv("AWS_SHARED_VPC_SECRET_ACCESS_KEY"),
+						"")),
+			)
+		} else {
+			file := awsSharedCredentialFile[0]
+			log.LogInfo("Got aws shared credential file path: %s ", file)
+			cfg, err = config.LoadDefaultConfig(context.TODO(),
+				config.WithRegion(region),
+				config.WithSharedCredentialsFiles([]string{file}),
+			)
+		}
 	} else {
 		if envCredential() {
 			log.LogInfo("Got AWS_ACCESS_KEY_ID env settings, going to build the config with the env")

--- a/pkg/aws/aws_client/env.go
+++ b/pkg/aws/aws_client/env.go
@@ -11,3 +11,9 @@ func envCredential() bool {
 func envAwsProfile() bool {
 	return os.Getenv("AWS_SHARED_CREDENTIALS_FILE") != ""
 }
+func envSharedVPCCredential() bool {
+	if os.Getenv("AWS_SHARED_VPC_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SHARED_VPC_SECRET_ACCESS_KEY") != "" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Create AWS shared VPC cluster in my local successfully with ENV `AWS_SHARED_VPC_ACCESS_KEY_ID` and `AWS_SHARED_VPC_SECRET_ACCESS_KEY`
```
Name:                       sdq-fpkho-xyiat
Domain Prefix:              sdq-fpkho-xyiat
Display Name:               sdq-fpkho-xyiat
ID:                         2lbu9eobrsfoqk8em08hu83n27eh9ceu
External ID:                6447bc95-36d6-48bf-856b-9cd3d1079350
Control Plane:              Customer Hosted
OpenShift Version:          4.19.11
Channel Group:              stable
DNS:                        sdq-fpkho-xyiat.rphg.s1.devshift.org
AWS Account:                989064034108
API URL:                    https://api.sdq-fpkho-xyiat.rphg.s1.devshift.org:6443
Console URL:                https://console-openshift-console.apps.sdq-fpkho-xyiat.rphg.s1.devshift.org
Region:                     us-east-2
Multi-AZ:                   true

Nodes:
 - Control plane:           3
 - Infra:                   3
 - Compute (Autoscaled):    3-6
Network:
 - Type:                    OVNKubernetes
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
 - Subnets:                 subnet-005c6599bffed20f1, subnet-07c959aabb1f0988d, subnet-0ef142435bd8698a1, subnet-0d481d27ed7ae41c7, subnet-06f743aa77b096f66, subnet-018b16b62f4bbe5a3
Infra ID:                   sdq-fpkho-xyiat-z4fpq
EC2 Metadata Http Tokens:   required
Role (STS) ARN:             arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-Installer-Role
Support Role ARN:           arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-Support-Role
Instance IAM Roles:
 - Control plane:           arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-ControlPlane-Role
 - Worker:                  arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-Worker-Role
Operator IAM Roles:
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-cloud-network-config-controller-c
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-machine-api-aws-cloud-credentials
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-cloud-credential-operator-cloud-c
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-image-registry-installer-cloud-cr
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-ingress-operator-cloud-credential
 - arn:aws:iam::989064034108:role/sdq-fpkho-xyiat-oper-openshift-cluster-csi-drivers-ebs-cloud-cre
Managed Policies:           No
State:                      ready 
Private:                    No
Delete Protection:          Disabled
Created:                    Sep 17 2025 04:02:07 UTC
User Workload Monitoring:   Disabled
FIPS mode:                  Enabled
Details Page:               https://console.dev.redhat.com/openshift/details/s/32oKwzw3XcYwrf88oTATCVHtm0s
OIDC Endpoint URL:          https://oidc.os1.devshift.org/2jopd2ggjafe972cq5h89einjro6681r (Managed)
Private Hosted Zone:
 - ID:                      Z0534840HKSJKPLQA6W
 - Role ARN:                arn:aws:iam::767397922229:role/sdq-fpkho-xyiat-shared-vpc-role
Etcd Encryption:            Enabled
```