### PR TITLE
OCM-18587 | Feat: Add helpers to enable field deprecation

### DIFF
--- a/pkg/deprecation/field_deprecation.go
+++ b/pkg/deprecation/field_deprecation.go
@@ -1,0 +1,85 @@
+package deprecation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/openshift-online/ocm-common/pkg/ocm/consts"
+)
+
+type fieldDeprecationsContextKey string
+
+const fieldDeprecationsKey fieldDeprecationsContextKey = "fieldDeprecations"
+
+// FieldDeprecations is stored in the request context and contains field deprecation information
+type FieldDeprecations struct {
+	messages map[string]map[string]string
+}
+
+func (f *FieldDeprecations) Add(field, message string, sunsetDate time.Time) error {
+	now := time.Now().UTC()
+	if now.After(sunsetDate) {
+		return errors.New(message)
+	}
+
+	f.messages[field] = map[string]string{
+		"details":    message,
+		"sunsetDate": sunsetDate.Format(time.RFC3339),
+	}
+	return nil
+}
+
+func (f *FieldDeprecations) ToJSON() ([]byte, error) {
+	output := make(map[string]string)
+	for field, message := range f.messages {
+		output[field] = message["details"]
+	}
+	return json.Marshal(output)
+}
+
+func (f *FieldDeprecations) IsEmpty() bool {
+	return len(f.messages) == 0
+}
+
+func NewFieldDeprecations() FieldDeprecations {
+	return FieldDeprecations{messages: make(map[string]map[string]string)}
+}
+
+func WithFieldDeprecations(ctx context.Context) context.Context {
+	return context.WithValue(ctx, fieldDeprecationsKey, NewFieldDeprecations())
+}
+
+func GetFieldDeprecations(ctx context.Context) FieldDeprecations {
+	fieldDeprecations, ok := ctx.Value(fieldDeprecationsKey).(FieldDeprecations)
+	if !ok {
+		return NewFieldDeprecations()
+	}
+	return fieldDeprecations
+}
+
+// FieldDeprecationResponseWriter is a wrapping for the response writer that sets field deprecation headers
+type FieldDeprecationResponseWriter struct {
+	http.ResponseWriter
+	Request *http.Request
+}
+
+func (w *FieldDeprecationResponseWriter) WriteHeader(statusCode int) {
+	w.setFieldDeprecationHeaders()
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *FieldDeprecationResponseWriter) Write(data []byte) (int, error) {
+	w.setFieldDeprecationHeaders()
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *FieldDeprecationResponseWriter) setFieldDeprecationHeaders() {
+	deprecatedFields := GetFieldDeprecations(w.Request.Context())
+	if !deprecatedFields.IsEmpty() {
+		deprecatedFieldsJSON, _ := deprecatedFields.ToJSON()
+		w.ResponseWriter.Header().Set(consts.OcmFieldDeprecation, string(deprecatedFieldsJSON))
+	}
+}

--- a/pkg/deprecation/transport_wrapper.go
+++ b/pkg/deprecation/transport_wrapper.go
@@ -3,6 +3,7 @@ package deprecation
 //go:generate mockgen -destination=test/mock_roundtripper.go -package=test net/http RoundTripper
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -49,35 +50,53 @@ func (w *TransportWrapper) handleDeprecationHeaders(resp *http.Response) {
 
 	deprecationHeader := resp.Header.Get(consts.DeprecationHeader)
 	messageHeader := resp.Header.Get(consts.OcmDeprecationMessage)
+	fieldDeprecationHeader := resp.Header.Get(consts.OcmFieldDeprecation)
 
-	if deprecationHeader != "" || messageHeader != "" {
-		w.printDeprecationWarning(deprecationHeader, messageHeader)
+	if deprecationHeader != "" || messageHeader != "" || fieldDeprecationHeader != "" {
+		w.printDeprecationWarning(deprecationHeader, messageHeader, fieldDeprecationHeader)
 	}
 }
 
 // printDeprecationWarning prints a deprecation warning to stderr
-func (w *TransportWrapper) printDeprecationWarning(deprecationHeader, messageHeader string) {
+func (w *TransportWrapper) printDeprecationWarning(deprecationHeader, messageHeader, fieldDeprecationHeader string) {
 	var message strings.Builder
-	message.WriteString("WARNING: You are using a deprecated OCM API\n")
 
-	if deprecationHeader != "" {
+	if deprecationHeader != "" || messageHeader != "" {
+		message.WriteString("WARNING: You are using a deprecated OCM API\n")
 		// Try to parse the date from the header
-		if deprecationTime, err := time.Parse(time.RFC3339, deprecationHeader); err == nil {
-			message.WriteString(fmt.Sprintf("This endpoint will be removed on: %s\n",
-				deprecationTime.Format(time.RFC3339)))
-		} else if deprecationTime, err := time.Parse(time.RFC1123Z, deprecationHeader); err == nil {
-			message.WriteString(fmt.Sprintf("This endpoint will be removed on: %s\n",
-				deprecationTime.Format(time.RFC1123Z)))
-		} else {
-			message.WriteString(fmt.Sprintf("Deprecation: %s\n", deprecationHeader))
+		if deprecationHeader != "" {
+			if deprecationTime, err := time.Parse(time.RFC3339, deprecationHeader); err == nil {
+				message.WriteString(fmt.Sprintf("This endpoint will be removed on: %s\n",
+					deprecationTime.Format(time.RFC3339)))
+			} else if deprecationTime, err := time.Parse(time.RFC1123Z, deprecationHeader); err == nil {
+				message.WriteString(fmt.Sprintf("This endpoint will be removed on: %s\n",
+					deprecationTime.Format(time.RFC1123Z)))
+			} else {
+				message.WriteString(fmt.Sprintf("Deprecation: %s\n", deprecationHeader))
+			}
 		}
-	}
 
-	if messageHeader != "" {
-		message.WriteString(fmt.Sprintf("Details: %s\n", messageHeader))
-	}
+		if messageHeader != "" {
+			message.WriteString(fmt.Sprintf("Details: %s\n", messageHeader))
+		}
 
-	message.WriteString("Please update your usage to avoid issues when this endpoint is removed\n")
+		message.WriteString("Please update your usage to avoid issues when this endpoint is removed\n")
+	} else if fieldDeprecationHeader != "" {
+		message.WriteString("WARNING: You are using OCM API fields that have been deprecated\n")
+
+		var deprecatedFieldsMap map[string]string
+		err := json.Unmarshal([]byte(fieldDeprecationHeader), &deprecatedFieldsMap)
+		if err != nil {
+			message.WriteString(fmt.Sprintf("Error parsing field deprecation header: %s\n", err))
+			return
+		}
+
+		for field, deprecationMessage := range deprecatedFieldsMap {
+			message.WriteString(fmt.Sprintf("- %s: %s\n", field, deprecationMessage))
+		}
+
+		message.WriteString("Please update your usage to avoid issues when these fields are removed\n")
+	}
 
 	fmt.Fprint(os.Stderr, message.String())
 }

--- a/pkg/ocm/consts/custom_headers.go
+++ b/pkg/ocm/consts/custom_headers.go
@@ -3,4 +3,5 @@ package consts
 const (
 	DeprecationHeader     = "Deprecation"
 	OcmDeprecationMessage = "X-OCM-Deprecation-Message"
+	OcmFieldDeprecation   = "X-OCM-Field-Deprecation"
 )


### PR DESCRIPTION
adds the `FieldDeprecations struct` and `FieldDeprecationResponseWriter struct` to enable the deprecation middleware to check and write headers for deprecated fields

- FieldDeprecations is bound to the request context and holds information about deprecated fields that can be added by the service handlers
- FieldDeprecationResponseWriter wraps `http.ResponseWriter` which is needed to set the field deprecation header after the service handlers have executed

for design see https://github.com/openshift-online/ddr-ocm/blob/main/ddrs/0219-field-deprecation.md