### PR TITLE
OCM-23324 | fix: handle duplicate security group error without panic

### DIFF
--- a/pkg/aws/errors/errors.go
+++ b/pkg/aws/errors/errors.go
@@ -34,6 +34,7 @@ const (
 	InvalidVpcID                 = "InvalidVpcID.NotFound"
 	InvalidAllocationID          = "InvalidAllocationID.NotFound"
 	InvalidGroup                 = "InvalidGroup.NotFound"
+	InvalidGroupDuplicate        = "InvalidGroup.Duplicate"
 	InvalidSubnetID              = "InvalidSubnetId.NotFound"
 	InvalidNatGatewayID          = "InvalidNatGatewayID.NotFound"
 )

--- a/pkg/test/vpc_client/security_group.go
+++ b/pkg/test/vpc_client/security_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	con "github.com/openshift-online/ocm-common/pkg/aws/consts"
+	awserrors "github.com/openshift-online/ocm-common/pkg/aws/errors"
 	"github.com/openshift-online/ocm-common/pkg/log"
 )
 
@@ -73,10 +74,30 @@ func (vpc *VPC) CreateAdditionalSecurityGroups(count int, namePrefix string, des
 	for createdsgNum < count {
 		sgName := fmt.Sprintf("%s-%d", namePrefix, createdsgNum)
 		sg, err := vpc.AWSClient.CreateSecurityGroup(vpc.VpcID, sgName, description)
+		var groupID string
 		if err != nil {
-			panic(err)
+			if !awserrors.IsErrorCode(err, awserrors.InvalidGroupDuplicate) {
+				return preparedSGs, err
+			}
+			log.LogInfo("Security group %s already exists in VPC %s, reusing it", sgName, vpc.VpcID)
+			existingSGs, listErr := vpc.AWSClient.ListSecurityGroups(vpc.VpcID)
+			if listErr != nil {
+				return preparedSGs, listErr
+			}
+			found := false
+			for _, existingSG := range existingSGs {
+				if *existingSG.GroupName == sgName {
+					groupID = *existingSG.GroupId
+					found = true
+					break
+				}
+			}
+			if !found {
+				return preparedSGs, fmt.Errorf("security group %s reported as duplicate but not found in VPC %s", sgName, vpc.VpcID)
+			}
+		} else {
+			groupID = *sg.GroupId
 		}
-		groupID := *sg.GroupId
 		cidrPortsMap := make(map[string][]int32)
 		cidrPortsMap[con.RouteDestinationCidrBlock] = append(cidrPortsMap[con.RouteDestinationCidrBlock], 22)
 		if len(ports) > 0 {
@@ -94,7 +115,7 @@ func (vpc *VPC) CreateAdditionalSecurityGroups(count int, namePrefix string, des
 
 		}
 
-		preparedSGs = append(preparedSGs, *sg.GroupId)
+		preparedSGs = append(preparedSGs, groupID)
 		createdsgNum++
 	}
 	return preparedSGs, nil

--- a/pkg/test/vpc_client/security_group_test.go
+++ b/pkg/test/vpc_client/security_group_test.go
@@ -1,0 +1,123 @@
+package vpc_client_test
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+	awserrors "github.com/openshift-online/ocm-common/pkg/aws/errors"
+	. "github.com/openshift-online/ocm-common/pkg/test/vpc_client"
+)
+
+var _ = Describe("CreateAdditionalSecurityGroups", func() {
+	var (
+		mockCtrl      *gomock.Controller
+		mockEC2Client *aws_client.MockEC2ClientAPI
+		vpc           *VPC
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockEC2Client = aws_client.NewMockEC2ClientAPI(mockCtrl)
+		vpc = NewVPC().
+			ID("vpc-0fa4cc34953703260").
+			CIDR("10.0.0.0/16").
+			AWSclient(&aws_client.AWSClient{Ec2Client: mockEC2Client})
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("should create a new security group successfully", func() {
+		mockEC2Client.EXPECT().
+			CreateSecurityGroup(gomock.Any(), gomock.Any()).
+			Return(&ec2.CreateSecurityGroupOutput{
+				GroupId: aws.String("sg-newgroup"),
+			}, nil)
+		mockEC2Client.EXPECT().
+			DescribeSecurityGroups(gomock.Any(), gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []types.SecurityGroup{{GroupId: aws.String("sg-newgroup")}},
+			}, nil).AnyTimes()
+		mockEC2Client.EXPECT().
+			CreateTags(gomock.Any(), gomock.Any()).
+			Return(&ec2.CreateTagsOutput{}, nil).AnyTimes()
+		mockEC2Client.EXPECT().
+			AuthorizeSecurityGroupIngress(gomock.Any(), gomock.Any()).
+			Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).AnyTimes()
+
+		sgIDs, err := vpc.CreateAdditionalSecurityGroups(1, "test-sg", "test description")
+		Expect(err).To(BeNil())
+		Expect(sgIDs).To(HaveLen(1))
+		Expect(sgIDs[0]).To(Equal("sg-newgroup"))
+	})
+
+	It("should reuse existing security group on InvalidGroup.Duplicate", func() {
+		sgName := "bastion-sg-0"
+		mockEC2Client.EXPECT().
+			CreateSecurityGroup(gomock.Any(), gomock.Any()).
+			Return(nil, &smithy.GenericAPIError{
+				Code:    awserrors.InvalidGroupDuplicate,
+				Message: fmt.Sprintf("The security group '%s' already exists for VPC 'vpc-0fa4cc34953703260'", sgName),
+			})
+		mockEC2Client.EXPECT().
+			DescribeSecurityGroups(gomock.Any(), gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []types.SecurityGroup{
+					{
+						GroupId:   aws.String("sg-existing"),
+						GroupName: aws.String(sgName),
+					},
+				},
+			}, nil)
+		mockEC2Client.EXPECT().
+			AuthorizeSecurityGroupIngress(gomock.Any(), gomock.Any()).
+			Return(&ec2.AuthorizeSecurityGroupIngressOutput{}, nil).AnyTimes()
+
+		sgIDs, err := vpc.CreateAdditionalSecurityGroups(1, "bastion-sg", "bastion description")
+		Expect(err).To(BeNil())
+		Expect(sgIDs).To(HaveLen(1))
+		Expect(sgIDs[0]).To(Equal("sg-existing"))
+	})
+
+	It("should return error on non-duplicate failures", func() {
+		mockEC2Client.EXPECT().
+			CreateSecurityGroup(gomock.Any(), gomock.Any()).
+			Return(nil, &smithy.GenericAPIError{
+				Code:    "UnauthorizedOperation",
+				Message: "You are not authorized to perform this operation.",
+			})
+
+		sgIDs, err := vpc.CreateAdditionalSecurityGroups(1, "test-sg", "test description")
+		Expect(err).NotTo(BeNil())
+		Expect(sgIDs).To(BeEmpty())
+	})
+
+	It("should return error when duplicate SG is not found in VPC", func() {
+		sgName := "bastion-sg-0"
+		mockEC2Client.EXPECT().
+			CreateSecurityGroup(gomock.Any(), gomock.Any()).
+			Return(nil, &smithy.GenericAPIError{
+				Code:    awserrors.InvalidGroupDuplicate,
+				Message: fmt.Sprintf("The security group '%s' already exists for VPC 'vpc-0fa4cc34953703260'", sgName),
+			})
+		mockEC2Client.EXPECT().
+			DescribeSecurityGroups(gomock.Any(), gomock.Any()).
+			Return(&ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []types.SecurityGroup{},
+			}, nil)
+
+		sgIDs, err := vpc.CreateAdditionalSecurityGroups(1, "bastion-sg", "bastion description")
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("reported as duplicate but not found"))
+		Expect(sgIDs).To(BeEmpty())
+	})
+})

--- a/pkg/test/vpc_client/suite_test.go
+++ b/pkg/test/vpc_client/suite_test.go
@@ -1,0 +1,13 @@
+package vpc_client_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVPCClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VPC Client Suite")
+}


### PR DESCRIPTION
Replace panic on InvalidGroup.Duplicate with graceful recovery: look up the existing security group by name and reuse it. Add unit tests covering success, duplicate reuse, and error paths.