### PR TITLE
OCM-24696 | feat: add shared STS external ID trust policy helpers

### DIFF
--- a/pkg/aws/ststrust/apply.go
+++ b/pkg/aws/ststrust/apply.go
@@ -1,0 +1,61 @@
+package ststrust
+
+import (
+	"fmt"
+)
+
+// ApplySTSExternalIDToTrustPolicy adds or updates sts:ExternalId on Allow sts:AssumeRole statements.
+// If entered is already present in the policy, the document is returned unchanged.
+// If the policy already defines other ExternalIds and entered is not among them, injection fails.
+func ApplySTSExternalIDToTrustPolicy(policyJSON, entered string) (string, error) {
+	if entered == "" {
+		return "", ErrExternalIDEmpty
+	}
+	if err := ValidateSTSExternalIDFormat(entered); err != nil {
+		return "", err
+	}
+	if policyJSON == "" {
+		return "", fmt.Errorf("trust policy document is empty")
+	}
+	if err := CanInjectSTSExternalID(policyJSON, entered); err != nil {
+		return "", err
+	}
+	ids, err := CollectSTSExternalIDsFromTrustPolicy(policyJSON)
+	if err != nil {
+		return "", err
+	}
+	for _, id := range ids {
+		if id == entered {
+			return policyJSON, nil
+		}
+	}
+	doc, err := parsePolicyDocument(policyJSON)
+	if err != nil {
+		return "", err
+	}
+	updated := false
+	for i := range doc.Statement {
+		if !statementAllowsAssumeRole(doc.Statement[i]) {
+			continue
+		}
+		setExternalIDCondition(&doc.Statement[i], entered)
+		updated = true
+	}
+	if !updated {
+		return policyJSON, nil
+	}
+	return marshalPolicyDocument(doc)
+}
+
+// setExternalIDCondition sets sts:ExternalId on the statement StringEquals block.
+func setExternalIDCondition(statement *PolicyStatement, externalID string) {
+	if statement.Condition == nil {
+		statement.Condition = map[string]interface{}{}
+	}
+	stringEquals, ok := statement.Condition["StringEquals"].(map[string]interface{})
+	if !ok || stringEquals == nil {
+		stringEquals = map[string]interface{}{}
+	}
+	stringEquals[externalIDCondition] = externalID
+	statement.Condition["StringEquals"] = stringEquals
+}

--- a/pkg/aws/ststrust/collect.go
+++ b/pkg/aws/ststrust/collect.go
@@ -1,0 +1,113 @@
+package ststrust
+
+import (
+	"fmt"
+)
+
+// CollectSTSExternalIDsFromTrustPolicy returns unique sts:ExternalId values from Allow statements
+// that include sts:AssumeRole. Values come from StringEquals and StringEqualsIfExists conditions.
+func CollectSTSExternalIDsFromTrustPolicy(policyJSON string) ([]string, error) {
+	if policyJSON == "" {
+		return nil, nil
+	}
+	doc, err := parsePolicyDocument(policyJSON)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, statement := range doc.Statement {
+		if !statementAllowsAssumeRole(statement) {
+			continue
+		}
+		ids = append(ids, collectExternalIDsFromCondition(statement.Condition)...)
+	}
+	return uniqueSorted(ids), nil
+}
+
+// ExternalIDMatchesTrustPolicy reports whether entered appears in the trust policy ExternalId set.
+func ExternalIDMatchesTrustPolicy(entered, policyJSON string) (bool, error) {
+	if entered == "" {
+		return false, ErrExternalIDEmpty
+	}
+	ids, err := CollectSTSExternalIDsFromTrustPolicy(policyJSON)
+	if err != nil {
+		return false, err
+	}
+	for _, id := range ids {
+		if id == entered {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// collectExternalIDsFromCondition extracts sts:ExternalId values from IAM Condition blocks.
+func collectExternalIDsFromCondition(condition map[string]interface{}) []string {
+	if condition == nil {
+		return nil
+	}
+	var ids []string
+	for _, key := range []string{"StringEquals", "StringEqualsIfExists"} {
+		raw, ok := condition[key]
+		if !ok {
+			continue
+		}
+		ids = append(ids, externalIDsFromConditionBlock(raw)...)
+	}
+	return ids
+}
+
+// externalIDsFromConditionBlock extracts sts:ExternalId from a single condition operator value.
+func externalIDsFromConditionBlock(raw interface{}) []string {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	value, ok := m[externalIDCondition]
+	if !ok {
+		return nil
+	}
+	return externalIDsFromValue(value)
+}
+
+// externalIDsFromValue normalizes string or array ExternalId condition values.
+func externalIDsFromValue(value interface{}) []string {
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	case []interface{}:
+		var ids []string
+		for _, el := range v {
+			if s, ok := el.(string); ok && s != "" {
+				ids = append(ids, s)
+			}
+		}
+		return ids
+	default:
+		return nil
+	}
+}
+
+// CanInjectSTSExternalID checks whether entered may be applied to an existing trust policy.
+// Injection is allowed when the policy has no ExternalId conditions or entered is already listed.
+func CanInjectSTSExternalID(existingPolicyJSON, entered string) error {
+	if entered == "" {
+		return ErrExternalIDEmpty
+	}
+	ids, err := CollectSTSExternalIDsFromTrustPolicy(existingPolicyJSON)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	for _, id := range ids {
+		if id == entered {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: existing trust policy defines %s", ErrExternalIDConflictOnInject, formatIDList(ids))
+}

--- a/pkg/aws/ststrust/constants.go
+++ b/pkg/aws/ststrust/constants.go
@@ -1,0 +1,14 @@
+package ststrust
+
+import "regexp"
+
+// Length and format limits for aws.sts.external_id (OCM Clusters Service parity).
+const (
+	// MinSTSExternalIDLength matches OCM Clusters Service validation for aws.sts.external_id.
+	MinSTSExternalIDLength = 2
+	// MaxSTSExternalIDLength matches OCM Clusters Service validation for aws.sts.external_id.
+	MaxSTSExternalIDLength = 1224
+)
+
+// STSExternalIDRegex matches OCM Clusters Service validation for aws.sts.external_id.
+var STSExternalIDRegex = regexp.MustCompile(`^[\w+=,.@:\/-]*$`)

--- a/pkg/aws/ststrust/discover.go
+++ b/pkg/aws/ststrust/discover.go
@@ -1,0 +1,27 @@
+package ststrust
+
+// DiscoverSTSExternalID returns a single external ID when discovery is unambiguous across
+// installer and support trust policies. Empty policies are skipped. Returns ("", nil) when
+// no ID should be sent to OCM (zero IDs or ambiguous multiple candidates without a unique intersection).
+func DiscoverSTSExternalID(installerPolicy, supportPolicy string) (string, error) {
+	installerIDs, err := CollectSTSExternalIDsFromTrustPolicy(installerPolicy)
+	if err != nil {
+		return "", err
+	}
+	supportIDs, err := CollectSTSExternalIDsFromTrustPolicy(supportPolicy)
+	if err != nil {
+		return "", err
+	}
+	union := setUnion(installerIDs, supportIDs)
+	if len(union) == 0 {
+		return "", nil
+	}
+	if len(union) == 1 {
+		return union[0], nil
+	}
+	intersection := setIntersection(installerIDs, supportIDs)
+	if len(intersection) == 1 {
+		return intersection[0], nil
+	}
+	return "", nil
+}

--- a/pkg/aws/ststrust/doc.go
+++ b/pkg/aws/ststrust/doc.go
@@ -1,0 +1,5 @@
+// Package ststrust provides helpers for STS external ID validation and IAM trust policy handling.
+//
+// External IDs are never auto-generated; callers supply user-provided values. Trust policy JSON may
+// be percent-encoded (see decodePolicyDocument); PathUnescape is used so '+' in external IDs is preserved.
+package ststrust

--- a/pkg/aws/ststrust/errors.go
+++ b/pkg/aws/ststrust/errors.go
@@ -1,0 +1,38 @@
+package ststrust
+
+import "errors"
+
+// Sentinel errors for STS external ID validation and trust policy operations.
+var (
+	// ErrExternalIDEmpty is returned when an operation requires a non-empty external ID.
+	ErrExternalIDEmpty = errors.New("STS external ID cannot be empty")
+	// ErrExternalIDFormat is returned when the external ID fails format or length validation.
+	ErrExternalIDFormat = errors.New("STS external ID format is invalid")
+	// ErrExternalIDNotInTrustPolicy is returned when the entered ID is not present in a role trust policy.
+	ErrExternalIDNotInTrustPolicy = errors.New("STS external ID is not present in role trust policy")
+	// ErrExternalIDConflictOnInject is returned when injection would add an ID not already allowed by the trust policy.
+	ErrExternalIDConflictOnInject = errors.New("STS external ID is not compatible with existing trust policy conditions")
+	// ErrNoTrustPolicyExternalID is returned when validation requires ExternalId conditions but none were found.
+	ErrNoTrustPolicyExternalID = errors.New("role trust policy has no sts:ExternalId condition")
+)
+
+// ExternalIDMismatchError describes a membership validation failure for a specific role.
+type ExternalIDMismatchError struct {
+	// RoleLabel identifies the installer or support role that failed validation.
+	RoleLabel string
+	// Entered is the user-supplied external ID.
+	Entered string
+	// FoundInRole lists sts:ExternalId values present in that role's trust policy.
+	FoundInRole []string
+}
+
+// Error implements the error interface.
+func (e *ExternalIDMismatchError) Error() string {
+	return "STS external ID '" + e.Entered + "' does not match trust policy for " + e.RoleLabel +
+		" (found: " + formatIDList(e.FoundInRole) + ")"
+}
+
+// Is reports whether target is ErrExternalIDNotInTrustPolicy.
+func (e *ExternalIDMismatchError) Is(target error) bool {
+	return target == ErrExternalIDNotInTrustPolicy
+}

--- a/pkg/aws/ststrust/policy.go
+++ b/pkg/aws/ststrust/policy.go
@@ -1,0 +1,154 @@
+package ststrust
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+)
+
+// Trust policy JSON constants for AssumeRole and ExternalId handling.
+const (
+	assumeRoleAction     = "sts:AssumeRole"
+	externalIDCondition  = "sts:ExternalId"
+	policyVersionDefault = "2012-10-17"
+)
+
+// PolicyDocument models an IAM trust policy document.
+type PolicyDocument struct {
+	// Version is the IAM policy version, typically "2012-10-17".
+	Version string `json:"Version,omitempty"`
+	// Statement holds trust policy statements.
+	Statement []PolicyStatement `json:"Statement"`
+}
+
+// PolicyStatement models a single IAM policy statement.
+type PolicyStatement struct {
+	// Sid is the optional statement identifier.
+	Sid string `json:"Sid,omitempty"`
+	// Effect is typically "Allow" or "Deny".
+	Effect string `json:"Effect"`
+	// Principal identifies who may assume the role.
+	Principal *PolicyStatementPrincipal `json:"Principal,omitempty"`
+	// Action is sts:AssumeRole or a list of actions.
+	Action interface{} `json:"Action,omitempty"`
+	// Resource is the optional resource element.
+	Resource interface{} `json:"Resource,omitempty"`
+	// Condition holds IAM condition operators such as StringEquals.
+	Condition map[string]interface{} `json:"Condition,omitempty"`
+}
+
+// PolicyStatementPrincipal models the Principal element in a trust policy statement.
+type PolicyStatementPrincipal struct {
+	// AWS lists AWS principal ARNs or account identifiers.
+	AWS interface{} `json:"AWS,omitempty"`
+	// Service lists AWS service principals.
+	Service interface{} `json:"Service,omitempty"`
+	// Federated is a federated identity provider ARN.
+	Federated string `json:"Federated,omitempty"`
+}
+
+// parsePolicyDocument decodes and unmarshals a trust policy JSON document.
+func parsePolicyDocument(policyJSON string) (*PolicyDocument, error) {
+	decoded, err := decodePolicyDocument(policyJSON)
+	if err != nil {
+		return nil, err
+	}
+	doc := &PolicyDocument{}
+	if err := json.Unmarshal([]byte(decoded), doc); err != nil {
+		return nil, fmt.Errorf("failed to parse trust policy JSON: %w", err)
+	}
+	return doc, nil
+}
+
+// marshalPolicyDocument serializes a trust policy document to JSON.
+func marshalPolicyDocument(doc *PolicyDocument) (string, error) {
+	if doc.Version == "" {
+		doc.Version = policyVersionDefault
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal trust policy JSON: %w", err)
+	}
+	return string(out), nil
+}
+
+// decodePolicyDocument percent-decodes policy JSON using PathUnescape.
+func decodePolicyDocument(policyJSON string) (string, error) {
+	decoded, err := url.PathUnescape(policyJSON)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode trust policy document: %w", err)
+	}
+	return decoded, nil
+}
+
+// statementAllowsAssumeRole reports whether the statement allows sts:AssumeRole.
+func statementAllowsAssumeRole(statement PolicyStatement) bool {
+	if statement.Effect != "Allow" {
+		return false
+	}
+	return actionIncludesAssumeRole(statement.Action)
+}
+
+// actionIncludesAssumeRole reports whether the Action element includes sts:AssumeRole.
+func actionIncludesAssumeRole(action interface{}) bool {
+	switch v := action.(type) {
+	case string:
+		return v == assumeRoleAction
+	case []interface{}:
+		for _, el := range v {
+			if s, ok := el.(string); ok && s == assumeRoleAction {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// uniqueSorted returns non-empty IDs in sorted order without duplicates.
+func uniqueSorted(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// setUnion returns the sorted union of two ID lists.
+func setUnion(a, b []string) []string {
+	return uniqueSorted(append(append([]string{}, a...), b...))
+}
+
+// setIntersection returns the sorted intersection of two ID lists.
+func setIntersection(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	lookup := make(map[string]struct{}, len(a))
+	for _, id := range a {
+		lookup[id] = struct{}{}
+	}
+	var out []string
+	for _, id := range b {
+		if _, ok := lookup[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return uniqueSorted(out)
+}
+
+// formatIDList formats external ID lists for error messages.
+func formatIDList(ids []string) string {
+	if len(ids) == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("%v", ids)
+}

--- a/pkg/aws/ststrust/ststrust_suite_test.go
+++ b/pkg/aws/ststrust/ststrust_suite_test.go
@@ -1,0 +1,13 @@
+package ststrust_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSTSTrust(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "STS trust policy external ID")
+}

--- a/pkg/aws/ststrust/ststrust_test.go
+++ b/pkg/aws/ststrust/ststrust_test.go
@@ -1,0 +1,487 @@
+package ststrust_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift-online/ocm-common/pkg/aws/ststrust"
+)
+
+const (
+	externalIDA = "223B9588-36A5-ECA4-BE8D-7C673B77CEC1"
+	externalIDB = "333B9588-36A5-ECA4-BE8D-7C673B77CDCD"
+)
+
+func loadFixture(name string) string {
+	_, filename, _, ok := runtime.Caller(0)
+	Expect(ok).To(BeTrue())
+	path := filepath.Join(filepath.Dir(filename), "testdata", name)
+	data, err := os.ReadFile(path)
+	Expect(err).NotTo(HaveOccurred())
+	return string(data)
+}
+
+func policyWithExternalID(externalID string) string {
+	policy := map[string]interface{}{
+		"Version": "2012-10-17",
+		"Statement": []map[string]interface{}{
+			{
+				"Effect": "Allow",
+				"Principal": map[string]interface{}{
+					"AWS": "arn:aws:iam::123456789012:role/test",
+				},
+				"Action": "sts:AssumeRole",
+				"Condition": map[string]interface{}{
+					"StringEquals": map[string]interface{}{
+						"sts:ExternalId": externalID,
+					},
+				},
+			},
+		},
+	}
+	out, err := json.Marshal(policy)
+	Expect(err).NotTo(HaveOccurred())
+	return string(out)
+}
+
+func policyWithMultipleExternalIDs(ids []string) string {
+	policy := map[string]interface{}{
+		"Version": "2012-10-17",
+		"Statement": []map[string]interface{}{
+			{
+				"Effect": "Allow",
+				"Principal": map[string]interface{}{
+					"AWS": "arn:aws:iam::123456789012:role/test",
+				},
+				"Action": "sts:AssumeRole",
+				"Condition": map[string]interface{}{
+					"StringEquals": map[string]interface{}{
+						"sts:ExternalId": ids,
+					},
+				},
+			},
+		},
+	}
+	out, err := json.Marshal(policy)
+	Expect(err).NotTo(HaveOccurred())
+	return string(out)
+}
+
+func policyWithTwoStatements(idA, idB string) string {
+	policy := map[string]interface{}{
+		"Version": "2012-10-17",
+		"Statement": []map[string]interface{}{
+			{
+				"Effect": "Allow",
+				"Principal": map[string]interface{}{
+					"AWS": "arn:aws:iam::123456789012:role/test",
+				},
+				"Action": "sts:AssumeRole",
+				"Condition": map[string]interface{}{
+					"StringEquals": map[string]interface{}{
+						"sts:ExternalId": idA,
+					},
+				},
+			},
+			{
+				"Effect": "Allow",
+				"Principal": map[string]interface{}{
+					"AWS": "arn:aws:iam::123456789012:role/other",
+				},
+				"Action": "sts:AssumeRole",
+				"Condition": map[string]interface{}{
+					"StringEquals": map[string]interface{}{
+						"sts:ExternalId": idB,
+					},
+				},
+			},
+		},
+	}
+	out, err := json.Marshal(policy)
+	Expect(err).NotTo(HaveOccurred())
+	return string(out)
+}
+
+var _ = Describe("STS external ID trust policy", func() {
+	Describe("ValidateSTSExternalIDFormat", func() {
+		It("accepts a valid external ID", func() {
+			Expect(ststrust.ValidateSTSExternalIDFormat(externalIDA)).To(Succeed())
+		})
+
+		It("rejects empty external ID", func() {
+			err := ststrust.ValidateSTSExternalIDFormat("")
+			Expect(errors.Is(err, ststrust.ErrExternalIDEmpty)).To(BeTrue())
+		})
+
+		It("rejects too-short external ID", func() {
+			err := ststrust.ValidateSTSExternalIDFormat("a")
+			Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+		})
+
+		It("rejects too-long external ID", func() {
+			longID := make([]byte, ststrust.MaxSTSExternalIDLength+1)
+			for i := range longID {
+				longID[i] = 'a'
+			}
+			err := ststrust.ValidateSTSExternalIDFormat(string(longID))
+			Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+		})
+
+		It("rejects external ID with invalid characters", func() {
+			err := ststrust.ValidateSTSExternalIDFormat("invalid id with spaces")
+			Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+		})
+	})
+
+	Describe("CollectSTSExternalIDsFromTrustPolicy", func() {
+		It("returns nil for empty policy", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(BeNil())
+		})
+
+		It("returns nil for installer fixture without ExternalId", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(loadFixture("sts_installer_trust_policy.json"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(BeEmpty())
+		})
+
+		It("returns nil for support fixture without ExternalId", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(loadFixture("sts_support_trust_policy.json"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(BeEmpty())
+		})
+
+		It("collects a single ExternalId", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(policyWithExternalID(externalIDA))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("collects ExternalIds from percent-encoded policy JSON", func() {
+			escaped := url.PathEscape(policyWithExternalID(externalIDA))
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(escaped)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("preserves plus signs in ExternalId values", func() {
+			const idWithPlus = "ab+cde"
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(policyWithExternalID(idWithPlus))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{idWithPlus}))
+		})
+
+		It("collects multiple ExternalIds from an array condition", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(policyWithMultipleExternalIDs([]string{externalIDA, externalIDB}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA, externalIDB}))
+		})
+
+		It("collects ExternalIds across multiple statements", func() {
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(policyWithTwoStatements(externalIDA, externalIDB))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA, externalIDB}))
+		})
+
+		It("collects ExternalId from StringEqualsIfExists", func() {
+			policy := map[string]interface{}{
+				"Version": "2012-10-17",
+				"Statement": []map[string]interface{}{
+					{
+						"Effect":  "Allow",
+						"Action":  []string{"sts:AssumeRole"},
+						"Condition": map[string]interface{}{
+							"StringEqualsIfExists": map[string]interface{}{
+								"sts:ExternalId": externalIDA,
+							},
+						},
+					},
+				},
+			}
+			out, err := json.Marshal(policy)
+			Expect(err).NotTo(HaveOccurred())
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(string(out))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("returns an error for invalid JSON", func() {
+			_, err := ststrust.CollectSTSExternalIDsFromTrustPolicy("{not-json")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("collects from policies with Action as a JSON array", func() {
+			policy := `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": ["sts:AssumeRole"],
+					"Condition": {
+						"StringEquals": { "sts:ExternalId": "` + externalIDA + `" }
+					}
+				}]
+			}`
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("ignores non-AssumeRole statements", func() {
+			policy := map[string]interface{}{
+				"Version": "2012-10-17",
+				"Statement": []map[string]interface{}{
+					{
+						"Effect": "Allow",
+						"Action": "s3:GetObject",
+						"Condition": map[string]interface{}{
+							"StringEquals": map[string]interface{}{
+								"sts:ExternalId": externalIDA,
+							},
+						},
+					},
+				},
+			}
+			out, err := json.Marshal(policy)
+			Expect(err).NotTo(HaveOccurred())
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(string(out))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(BeEmpty())
+		})
+	})
+
+	Describe("ExternalIDMatchesTrustPolicy", func() {
+		It("returns true when entered is in the policy", func() {
+			match, err := ststrust.ExternalIDMatchesTrustPolicy(externalIDA, policyWithExternalID(externalIDA))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(match).To(BeTrue())
+		})
+
+		It("returns false when entered is not in the policy", func() {
+			match, err := ststrust.ExternalIDMatchesTrustPolicy(externalIDA, policyWithExternalID(externalIDB))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(match).To(BeFalse())
+		})
+
+		It("returns error when entered is empty", func() {
+			_, err := ststrust.ExternalIDMatchesTrustPolicy("", policyWithExternalID(externalIDA))
+			Expect(errors.Is(err, ststrust.ErrExternalIDEmpty)).To(BeTrue())
+		})
+	})
+
+	Describe("ApplySTSExternalIDToTrustPolicy", func() {
+		It("injects ExternalId into installer fixture", func() {
+			base := loadFixture("sts_installer_trust_policy.json")
+			updated, err := ststrust.ApplySTSExternalIDToTrustPolicy(base, externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("injects ExternalId into support fixture", func() {
+			base := loadFixture("sts_support_trust_policy.json")
+			updated, err := ststrust.ApplySTSExternalIDToTrustPolicy(base, externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+			ids, err := ststrust.CollectSTSExternalIDsFromTrustPolicy(updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(Equal([]string{externalIDA}))
+		})
+
+		It("is idempotent when ExternalId already present", func() {
+			policy := policyWithExternalID(externalIDA)
+			updated, err := ststrust.ApplySTSExternalIDToTrustPolicy(policy, externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(Equal(policy))
+		})
+
+		It("fails when existing policy defines a different ExternalId set", func() {
+			policy := policyWithExternalID(externalIDB)
+			_, err := ststrust.ApplySTSExternalIDToTrustPolicy(policy, externalIDA)
+			Expect(errors.Is(err, ststrust.ErrExternalIDConflictOnInject)).To(BeTrue())
+		})
+
+		It("allows injection when entered matches one of multiple IDs", func() {
+			policy := policyWithMultipleExternalIDs([]string{externalIDA, externalIDB})
+			updated, err := ststrust.ApplySTSExternalIDToTrustPolicy(policy, externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(Equal(policy))
+		})
+
+		It("rejects empty external ID", func() {
+			_, err := ststrust.ApplySTSExternalIDToTrustPolicy(loadFixture("sts_installer_trust_policy.json"), "")
+			Expect(errors.Is(err, ststrust.ErrExternalIDEmpty)).To(BeTrue())
+		})
+
+		It("rejects empty trust policy document", func() {
+			_, err := ststrust.ApplySTSExternalIDToTrustPolicy("", externalIDA)
+			Expect(err).To(MatchError(ContainSubstring("trust policy document is empty")))
+		})
+
+		It("rejects invalid external ID format", func() {
+			_, err := ststrust.ApplySTSExternalIDToTrustPolicy(loadFixture("sts_installer_trust_policy.json"), "x")
+			Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+		})
+	})
+
+	Describe("ValidateEnteredForRoleTrustPolicies", func() {
+		It("succeeds when entered matches both roles", func() {
+			installer := policyWithMultipleExternalIDs([]string{externalIDA, externalIDB})
+			support := policyWithExternalID(externalIDA)
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(externalIDA, installer, support)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("fails when support role does not contain entered ID", func() {
+			installer := policyWithExternalID(externalIDA)
+			support := policyWithExternalID(externalIDB)
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(externalIDA, installer, support)
+			var mismatch *ststrust.ExternalIDMismatchError
+			Expect(errors.As(err, &mismatch)).To(BeTrue())
+			Expect(mismatch.RoleLabel).To(Equal("support role"))
+		})
+
+		It("fails when installer trust policy has no ExternalId", func() {
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(
+				externalIDA,
+				loadFixture("sts_installer_trust_policy.json"),
+				"",
+			)
+			Expect(errors.Is(err, ststrust.ErrNoTrustPolicyExternalID)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("installer role"))
+		})
+
+		It("fails when support trust policy has no ExternalId", func() {
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(
+				externalIDA,
+				"",
+				loadFixture("sts_support_trust_policy.json"),
+			)
+			Expect(errors.Is(err, ststrust.ErrNoTrustPolicyExternalID)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("support role"))
+		})
+
+		It("succeeds when only support policy is provided and matches", func() {
+			support := policyWithExternalID(externalIDA)
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(externalIDA, "", support)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("fails when neither installer nor support policy is provided", func() {
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(externalIDA, "", "")
+			Expect(errors.Is(err, ststrust.ErrNoTrustPolicyExternalID)).To(BeTrue())
+		})
+
+		It("fails when installer role does not contain entered ID", func() {
+			installer := policyWithExternalID(externalIDB)
+			support := policyWithExternalID(externalIDA)
+			err := ststrust.ValidateEnteredForRoleTrustPolicies(externalIDA, installer, support)
+			var mismatch *ststrust.ExternalIDMismatchError
+			Expect(errors.As(err, &mismatch)).To(BeTrue())
+			Expect(mismatch.RoleLabel).To(Equal("installer role"))
+			Expect(errors.Is(err, ststrust.ErrExternalIDNotInTrustPolicy)).To(BeTrue())
+			Expect(mismatch.Error()).To(ContainSubstring(externalIDA))
+		})
+
+		It("rejects invalid entered format before checking policies", func() {
+			err := ststrust.ValidateEnteredForRoleTrustPolicies("x", policyWithExternalID(externalIDA), "")
+			Expect(errors.Is(err, ststrust.ErrExternalIDFormat)).To(BeTrue())
+		})
+	})
+
+	Describe("DiscoverSTSExternalID", func() {
+		It("returns empty when no ExternalIds exist", func() {
+			id, err := ststrust.DiscoverSTSExternalID(
+				loadFixture("sts_installer_trust_policy.json"),
+				loadFixture("sts_support_trust_policy.json"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(BeEmpty())
+		})
+
+		It("returns sole union member from installer policy only", func() {
+			installer := policyWithExternalID(externalIDA)
+			id, err := ststrust.DiscoverSTSExternalID(installer, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(externalIDA))
+		})
+
+		It("returns sole union member from support policy only", func() {
+			support := policyWithExternalID(externalIDA)
+			id, err := ststrust.DiscoverSTSExternalID("", support)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(externalIDA))
+		})
+
+		It("returns sole union member from support fixture with ExternalId", func() {
+			support := loadFixture("sts_support_trust_policy.json")
+			updated, err := ststrust.ApplySTSExternalIDToTrustPolicy(support, externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+			id, err := ststrust.DiscoverSTSExternalID("", updated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(externalIDA))
+		})
+
+		It("returns intersection member when union is ambiguous", func() {
+			installer := policyWithMultipleExternalIDs([]string{externalIDA, externalIDB})
+			support := policyWithExternalID(externalIDA)
+			id, err := ststrust.DiscoverSTSExternalID(installer, support)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(externalIDA))
+		})
+
+		It("returns empty when union has multiple IDs with no single intersection", func() {
+			installer := policyWithExternalID(externalIDA)
+			support := policyWithExternalID(externalIDB)
+			id, err := ststrust.DiscoverSTSExternalID(installer, support)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(BeEmpty())
+		})
+	})
+
+	Describe("CanInjectSTSExternalID", func() {
+		It("allows injection into installer fixture without ExternalId", func() {
+			err := ststrust.CanInjectSTSExternalID(loadFixture("sts_installer_trust_policy.json"), externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows injection into support fixture without ExternalId", func() {
+			err := ststrust.CanInjectSTSExternalID(loadFixture("sts_support_trust_policy.json"), externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows when entered is in existing set", func() {
+			err := ststrust.CanInjectSTSExternalID(policyWithMultipleExternalIDs([]string{externalIDA, externalIDB}), externalIDA)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects empty external ID", func() {
+			err := ststrust.CanInjectSTSExternalID(loadFixture("sts_installer_trust_policy.json"), "")
+			Expect(errors.Is(err, ststrust.ErrExternalIDEmpty)).To(BeTrue())
+		})
+
+		It("fails when entered is not in existing ExternalId set", func() {
+			err := ststrust.CanInjectSTSExternalID(policyWithExternalID(externalIDB), externalIDA)
+			Expect(errors.Is(err, ststrust.ErrExternalIDConflictOnInject)).To(BeTrue())
+		})
+	})
+
+	Describe("DiscoverSTSExternalID error paths", func() {
+		It("returns error when installer policy JSON is invalid", func() {
+			_, err := ststrust.DiscoverSTSExternalID("{bad", policyWithExternalID(externalIDA))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error when support policy JSON is invalid", func() {
+			_, err := ststrust.DiscoverSTSExternalID(policyWithExternalID(externalIDA), "{bad")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/aws/ststrust/testdata/sts_installer_trust_policy.json
+++ b/pkg/aws/ststrust/testdata/sts_installer_trust_policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::123456789012:role/RH-Managed-OpenShift-Installer"
+                ]
+            },
+            "Action": [
+                "sts:AssumeRole"
+            ]
+        }
+    ]
+}

--- a/pkg/aws/ststrust/testdata/sts_support_trust_policy.json
+++ b/pkg/aws/ststrust/testdata/sts_support_trust_policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::123456789012:role/RH-Technical-Support-Access"
+                ]
+            },
+            "Action": [
+                "sts:AssumeRole"
+            ]
+        }
+    ]
+}

--- a/pkg/aws/ststrust/validate.go
+++ b/pkg/aws/ststrust/validate.go
@@ -1,0 +1,71 @@
+package ststrust
+
+import (
+	"fmt"
+)
+
+// Role labels used in validation and mismatch errors.
+const (
+	roleLabelInstaller = "installer role"
+	roleLabelSupport   = "support role"
+)
+
+// ValidateSTSExternalIDFormat validates length and character set for aws.sts.external_id.
+func ValidateSTSExternalIDFormat(entered string) error {
+	if entered == "" {
+		return ErrExternalIDEmpty
+	}
+	if len(entered) < MinSTSExternalIDLength {
+		return fmt.Errorf("%w: must be at least %d characters", ErrExternalIDFormat, MinSTSExternalIDLength)
+	}
+	if len(entered) > MaxSTSExternalIDLength {
+		return fmt.Errorf("%w: must be at most %d characters", ErrExternalIDFormat, MaxSTSExternalIDLength)
+	}
+	if !STSExternalIDRegex.MatchString(entered) {
+		return fmt.Errorf("%w: must match %s", ErrExternalIDFormat, STSExternalIDRegex.String())
+	}
+	return nil
+}
+
+// ValidateEnteredForRoleTrustPolicies ensures entered is present in each non-empty role trust policy.
+// Empty installer or support policy strings are skipped. Callers must supply a user-entered external ID.
+func ValidateEnteredForRoleTrustPolicies(entered, installerPolicy, supportPolicy string) error {
+	if err := ValidateSTSExternalIDFormat(entered); err != nil {
+		return err
+	}
+	if installerPolicy == "" && supportPolicy == "" {
+		return fmt.Errorf("%w: no installer or support trust policy provided", ErrNoTrustPolicyExternalID)
+	}
+	if installerPolicy != "" {
+		if err := validateEnteredForPolicy(entered, installerPolicy, roleLabelInstaller); err != nil {
+			return err
+		}
+	}
+	if supportPolicy != "" {
+		if err := validateEnteredForPolicy(entered, supportPolicy, roleLabelSupport); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEnteredForPolicy checks that entered appears in a single role trust policy.
+func validateEnteredForPolicy(entered, policyJSON, roleLabel string) error {
+	ids, err := CollectSTSExternalIDsFromTrustPolicy(policyJSON)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("%w for %s", ErrNoTrustPolicyExternalID, roleLabel)
+	}
+	for _, id := range ids {
+		if id == entered {
+			return nil
+		}
+	}
+	return &ExternalIDMismatchError{
+		RoleLabel:   roleLabel,
+		Entered:     entered,
+		FoundInRole: ids,
+	}
+}

--- a/pkg/rosa/accountroles/external_id.go
+++ b/pkg/rosa/accountroles/external_id.go
@@ -1,0 +1,12 @@
+package accountroles
+
+// RequiresSTSExternalIDInTrustPolicy reports whether account role creation should embed
+// sts:ExternalId in the trust policy when an external ID is provided by the user.
+func RequiresSTSExternalIDInTrustPolicy(roleKey string) bool {
+	switch roleKey {
+	case InstallerAccountRole, SupportAccountRole:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/rosa/accountroles/external_id_test.go
+++ b/pkg/rosa/accountroles/external_id_test.go
@@ -1,0 +1,23 @@
+package accountroles_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift-online/ocm-common/pkg/rosa/accountroles"
+)
+
+var _ = Describe("RequiresSTSExternalIDInTrustPolicy", func() {
+	It("returns true for installer and support", func() {
+		Expect(RequiresSTSExternalIDInTrustPolicy(InstallerAccountRole)).To(BeTrue())
+		Expect(RequiresSTSExternalIDInTrustPolicy(SupportAccountRole)).To(BeTrue())
+	})
+
+	It("returns false for worker and control plane", func() {
+		Expect(RequiresSTSExternalIDInTrustPolicy(WorkerAccountRole)).To(BeFalse())
+		Expect(RequiresSTSExternalIDInTrustPolicy(ControlPlaneAccountRole)).To(BeFalse())
+	})
+
+	It("returns false for unknown role keys", func() {
+		Expect(RequiresSTSExternalIDInTrustPolicy("unknown")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## Description

Adds shared helpers for ROSA STS `sts:ExternalId` support ([ROSA-786](https://redhat.atlassian.net/browse/ROSA-786) / Phase 1).

- New package `pkg/aws/ststrust`: validate external ID format (OCM-aligned), collect ExternalIds from IAM trust policies, inject `sts:ExternalId` on Allow `sts:AssumeRole` statements, discover a single unambiguous ID across installer/support policies, and validate user-entered IDs against role trust policies.
- New `RequiresSTSExternalIDInTrustPolicy` in `pkg/rosa/accountroles` so only installer and support account roles receive trust-policy injection when a user supplies an external ID.

Downstream repos (ROSA CLI, terraform-provider-rhcs, cluster-api-provider-aws) will bump `ocm-common` after a release tag is cut to proceed with next phase of feature. 

JIRA: [OCM-24696](https://redhat.atlassian.net/browse/OCM-24696)
Related: [ROSA-786](https://redhat.atlassian.net/browse/ROSA-786)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable): N/A
- [ ] Manual verification completed: N/A

**Validation steps for reviewers:**

```bash
go test ./pkg/aws/ststrust/... ./pkg/rosa/accountroles/... -coverprofile=cover.out -covermode=atomic
go tool cover -func=cover.out | grep -E 'ststrust|external_id|total'
make test
go build ./...
```

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass