### PR TITLE
ROSAENG-7031 | feat: add OCP 5.x version normalize/denormalize helpers

### DIFF
--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,0 +1,31 @@
+package utils
+
+import "fmt"
+
+const (
+	OcpMajorVersion4 = 4
+	OcpMajorVersion5 = 5
+	V5MinorOffset    = 23 // OCP 5.0 == 4.23
+)
+
+// NormalizeToV4 converts an OCP version to the 4.x scheme for skew arithmetic.
+// OCP 5.0 maps to 4.23, 5.1 to 4.24, etc. OCP 4.x versions pass through unchanged.
+func NormalizeToV4(major, minor int) (int, int, error) {
+	switch major {
+	case OcpMajorVersion4:
+		return major, minor, nil
+	case OcpMajorVersion5:
+		return OcpMajorVersion4, minor + V5MinorOffset, nil
+	default:
+		return 0, 0, fmt.Errorf("unsupported OCP major version: %d", major)
+	}
+}
+
+// DenormalizeFromV4 converts a normalized 4.x minor version back to display form.
+// A minor >= 23 maps to OCP 5.x (e.g., 23 → 5.0, 24 → 5.1). Otherwise returns 4.x.
+func DenormalizeFromV4(minor int) (int, int) {
+	if minor >= V5MinorOffset {
+		return OcpMajorVersion5, minor - V5MinorOffset
+	}
+	return OcpMajorVersion4, minor
+}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestNormalizeToV4(t *testing.T) {
+	tests := []struct {
+		name      string
+		major     int
+		minor     int
+		wantMajor int
+		wantMinor int
+		wantErr   bool
+	}{
+		{"4.18 passthrough", 4, 18, 4, 18, false},
+		{"4.22 passthrough", 4, 22, 4, 22, false},
+		{"5.0 normalizes to 4.23", 5, 0, 4, 23, false},
+		{"5.1 normalizes to 4.24", 5, 1, 4, 24, false},
+		{"5.2 normalizes to 4.25", 5, 2, 4, 25, false},
+		{"major 3 unsupported", 3, 0, 0, 0, true},
+		{"major 6 unsupported", 6, 0, 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMajor, gotMinor, err := NormalizeToV4(tt.major, tt.minor)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeToV4(%d, %d) error = %v, wantErr %v", tt.major, tt.minor, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if gotMajor != tt.wantMajor || gotMinor != tt.wantMinor {
+					t.Errorf("NormalizeToV4(%d, %d) = (%d, %d), want (%d, %d)",
+						tt.major, tt.minor, gotMajor, gotMinor, tt.wantMajor, tt.wantMinor)
+				}
+			}
+		})
+	}
+}
+
+func TestDenormalizeFromV4(t *testing.T) {
+	tests := []struct {
+		name      string
+		minor     int
+		wantMajor int
+		wantMinor int
+	}{
+		{"minor 18 stays 4.18", 18, 4, 18},
+		{"minor 22 stays 4.22", 22, 4, 22},
+		{"minor 23 becomes 5.0", 23, 5, 0},
+		{"minor 24 becomes 5.1", 24, 5, 1},
+		{"minor 25 becomes 5.2", 25, 5, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMajor, gotMinor := DenormalizeFromV4(tt.minor)
+			if gotMajor != tt.wantMajor || gotMinor != tt.wantMinor {
+				t.Errorf("DenormalizeFromV4(%d) = (%d, %d), want (%d, %d)",
+					tt.minor, gotMajor, gotMinor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

OCP 5.x uses dual versioning where 5.0 is the same release as 4.23. Any version skew arithmetic that compares minor versions directly breaks for cross-major scenarios (e.g., a control plane at 5.0 with a node pool at 4.22 computes 0 - 22 = -22 instead of the correct 23 - 22 = 1).
  
This adds two helpers to pkg/utils/ that convert between display and normalized version forms:
  
- NormalizeToV4(major, minor) — converts 5.x to 4.x scheme (5.0 → 4.23, 5.1 → 4.24). 4.x passes through unchanged. Returns error for unsupported major versions.
- DenormalizeFromV4(minor) — converts normalized minor back to display form (23 → 5.0, 24 → 5.1, 18 → 4.18).

Mirrors the reference implementation in HyperShift (https://github.com/openshift/hypershift/blob/main/support/supportedversion/version.go#L386).
  
Version mapping

  | Display | Normalized |
  |---------|------------|
  | 4.22    | 4.22       |
  | 5.0     | 4.23       |
  | 5.1     | 4.24       |
  | 5.2     | 4.25       |

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
