### PR TITLE
ROSAENG-60102: Fix VPC cleanup to release all EIPs and continue on errors

### DIFF
--- a/pkg/aws/aws_client/ec2_client_interface.go
+++ b/pkg/aws/aws_client/ec2_client_interface.go
@@ -38,6 +38,7 @@ type EC2ClientAPI interface {
 	DeleteKeyPair(ctx context.Context, params *ec2.DeleteKeyPairInput, optFns ...func(*ec2.Options)) (*ec2.DeleteKeyPairOutput, error)
 	DeleteNatGateway(ctx context.Context, params *ec2.DeleteNatGatewayInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNatGatewayOutput, error)
 	DeleteNetworkAclEntry(ctx context.Context, params *ec2.DeleteNetworkAclEntryInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkAclEntryOutput, error)
+	DetachNetworkInterface(ctx context.Context, params *ec2.DetachNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DetachNetworkInterfaceOutput, error)
 	DeleteNetworkInterface(ctx context.Context, params *ec2.DeleteNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error)
 	DeleteRouteTable(ctx context.Context, params *ec2.DeleteRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
 	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)

--- a/pkg/aws/aws_client/mock_ec2_client.go
+++ b/pkg/aws/aws_client/mock_ec2_client.go
@@ -519,6 +519,26 @@ func (mr *MockEC2ClientAPIMockRecorder) DeleteNetworkAclEntry(ctx, params any, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclEntry", reflect.TypeOf((*MockEC2ClientAPI)(nil).DeleteNetworkAclEntry), varargs...)
 }
 
+// DetachNetworkInterface mocks base method.
+func (m *MockEC2ClientAPI) DetachNetworkInterface(ctx context.Context, params *ec2.DetachNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DetachNetworkInterfaceOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DetachNetworkInterface", varargs...)
+	ret0, _ := ret[0].(*ec2.DetachNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetachNetworkInterface indicates an expected call of DetachNetworkInterface.
+func (mr *MockEC2ClientAPIMockRecorder) DetachNetworkInterface(ctx, params any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachNetworkInterface", reflect.TypeOf((*MockEC2ClientAPI)(nil).DetachNetworkInterface), varargs...)
+}
+
 // DeleteNetworkInterface mocks base method.
 func (m *MockEC2ClientAPI) DeleteNetworkInterface(ctx context.Context, params *ec2.DeleteNetworkInterfaceInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/aws_client/network_interface.go
+++ b/pkg/aws/aws_client/network_interface.go
@@ -68,6 +68,20 @@ func (client *AWSClient) GetNetworkInterfacesByInstanceID(instanceID string) ([]
 	return output.NetworkInterfaces, nil
 }
 
+func (client *AWSClient) DetachNetworkInterface(attachmentID string, force bool) error {
+	input := &ec2.DetachNetworkInterfaceInput{
+		AttachmentId: aws.String(attachmentID),
+		Force:        aws.Bool(force),
+	}
+	_, err := client.Ec2Client.DetachNetworkInterface(context.TODO(), input)
+	if err != nil {
+		log.LogError("Detach network interface attachment %s failed: %s", attachmentID, err)
+		return err
+	}
+	log.LogInfo("Detached network interface attachment %s", attachmentID)
+	return nil
+}
+
 func (client *AWSClient) DeleteNetworkInterface(networkinterface types.NetworkInterface) error {
 	association := networkinterface.Association
 	if association != nil {

--- a/pkg/test/vpc_client/nat_gateway.go
+++ b/pkg/test/vpc_client/nat_gateway.go
@@ -1,42 +1,53 @@
 package vpc_client
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/openshift-online/ocm-common/pkg/log"
 )
 
 func (vpc *VPC) DeleteVPCNatGateways(vpcID string) error {
-
-	var delERR error
 	natGateways, err := vpc.AWSClient.ListNatGateways(vpcID)
 	if err != nil {
 		return err
 	}
-	var wg sync.WaitGroup
-	allocationId := ""
+
+	var allocationIDs []string
 	for _, ngw := range natGateways {
-		if len(ngw.NatGatewayAddresses) > 0 {
-			for _, add := range ngw.NatGatewayAddresses {
-				allocationId = *add.AllocationId
+		for _, addr := range ngw.NatGatewayAddresses {
+			if addr.AllocationId != nil {
+				allocationIDs = append(allocationIDs, *addr.AllocationId)
 			}
 		}
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var delErrs []error
+	for _, ngw := range natGateways {
 		log.LogInfo("Deleting nat gateway %s", *ngw.NatGatewayId)
 		wg.Add(1)
 		go func(gateWayID string) {
 			defer wg.Done()
-			_, err = vpc.AWSClient.DeleteNatGateway(gateWayID, 180)
+			_, err := vpc.AWSClient.DeleteNatGateway(gateWayID, 180)
 			if err != nil {
-				delERR = err
+				mu.Lock()
+				delErrs = append(delErrs, err)
+				mu.Unlock()
 			}
 		}(*ngw.NatGatewayId)
 	}
 	wg.Wait()
-	if delERR != nil {
-		return delERR
+
+	var releaseErrs []error
+	for _, allocID := range allocationIDs {
+		log.LogInfo("Releasing EIP allocation %s", allocID)
+		if err := vpc.AWSClient.ReleaseAddressWithAllocationID(allocID); err != nil {
+			releaseErrs = append(releaseErrs, err)
+		}
 	}
-	if allocationId != "" {
-		err = vpc.AWSClient.ReleaseAddressWithAllocationID(allocationId)
-	}
-	return err
+
+	allErrs := append(delErrs, releaseErrs...)
+	return errors.Join(allErrs...)
 }

--- a/pkg/test/vpc_client/network_interface.go
+++ b/pkg/test/vpc_client/network_interface.go
@@ -1,16 +1,32 @@
 package vpc_client
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openshift-online/ocm-common/pkg/log"
+)
+
 func (vpc *VPC) DeleteVPCNetworkInterfaces() error {
 	networkInterfaces, err := vpc.AWSClient.DescribeNetWorkInterface(vpc.VpcID)
 	if err != nil {
 		return err
 	}
 
+	var errs []error
 	for _, networkInterface := range networkInterfaces {
-		err = vpc.AWSClient.DeleteNetworkInterface(networkInterface)
-		if err != nil {
-			return err
+		if networkInterface.Attachment != nil && networkInterface.Attachment.AttachmentId != nil {
+			log.LogInfo("Detaching network interface %s", *networkInterface.NetworkInterfaceId)
+			if err := vpc.AWSClient.DetachNetworkInterface(*networkInterface.Attachment.AttachmentId, true); err != nil {
+				log.LogError("Detach network interface %s failed: %s", *networkInterface.NetworkInterfaceId, err)
+				errs = append(errs, fmt.Errorf("detach ENI %s: %w", *networkInterface.NetworkInterfaceId, err))
+				continue
+			}
+		}
+		if err := vpc.AWSClient.DeleteNetworkInterface(networkInterface); err != nil {
+			errs = append(errs, fmt.Errorf("delete ENI %s: %w", *networkInterface.NetworkInterfaceId, err))
 		}
 	}
-	return nil
+
+	return errors.Join(errs...)
 }

--- a/pkg/test/vpc_client/vpc.go
+++ b/pkg/test/vpc_client/vpc.go
@@ -1,6 +1,7 @@
 package vpc_client
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -68,89 +69,85 @@ func (vpc *VPC) DeleteVPCChain(totalClean ...bool) error {
 		return fmt.Errorf("got empty vpc ID to clean. Make sure you loaded it from AWS")
 	}
 	log.LogInfo("Going to delete the vpc and follow resources by ID: %s", vpcID)
+
+	var errs []error
+
 	log.LogInfo("Going to terminate proxy instances if exists")
-	err := vpc.TerminateVPCInstances(true)
-	if err != nil {
+	if err := vpc.TerminateVPCInstances(true); err != nil {
 		log.LogError("Delete vpc instances meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("terminate proxy instances: %w", err))
+	} else {
+		log.LogInfo("Delete vpc instances successfully")
 	}
-	log.LogInfo("Delete vpc instances successfully")
 
 	log.LogInfo("Going to delete proxy security group")
-	err = vpc.DeleteVPCSecurityGroups(true)
-	if err != nil {
+	if err := vpc.DeleteVPCSecurityGroups(true); err != nil {
 		log.LogError("Delete vpc proxy security group meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete proxy security groups: %w", err))
+	} else {
+		log.LogInfo("Delete vpc proxy security group successfully")
 	}
-	log.LogInfo("Delete vpc proxy security group successfully")
 
-	err = vpc.DeleteVPCRouteTables(vpcID)
-	if err != nil {
+	if err := vpc.DeleteVPCRouteTables(vpcID); err != nil {
 		log.LogError("Delete vpc route tables meets error: %s", err.Error())
-		return err
-	}
-	log.LogInfo("Delete vpc route tables successfully")
-
-	err = vpc.DeleteVPCNatGateways(vpcID)
-	if err != nil {
-		log.LogError("Delete vpc nat gatways meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete route tables: %w", err))
+	} else {
+		log.LogInfo("Delete vpc route tables successfully")
 	}
 
-	log.LogInfo("Delete vpc nat gateways successfully")
-	err = vpc.AWSClient.DeleteVPCEndpoints(vpc.VpcID)
-	if err != nil {
+	if err := vpc.DeleteVPCNatGateways(vpcID); err != nil {
+		log.LogError("Delete vpc nat gateways meets error: %s", err.Error())
+		errs = append(errs, fmt.Errorf("delete nat gateways: %w", err))
+	} else {
+		log.LogInfo("Delete vpc nat gateways successfully")
+	}
+
+	if err := vpc.AWSClient.DeleteVPCEndpoints(vpc.VpcID); err != nil {
 		log.LogError("Delete vpc endpoints meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete vpc endpoints: %w", err))
 	}
+
 	if len(totalClean) == 1 && totalClean[0] {
 		log.LogInfo("Got total clean set, going to delete other possible resource leak")
-		// Delete leak instances
+
 		log.LogInfo("Going to terminate the leak instances if exist")
-		err = vpc.TerminateVPCInstances(false)
-		if err != nil {
+		if err := vpc.TerminateVPCInstances(false); err != nil {
 			log.LogError("Terminate vpc instances meets error: %s", err.Error())
-			return err
+			errs = append(errs, fmt.Errorf("terminate leak instances: %w", err))
 		}
 
-		// Delete leak ELBs
-		err = vpc.DeleteVPCELBs()
-		if err != nil {
+		if err := vpc.DeleteVPCELBs(); err != nil {
 			log.LogError("Delete vpc load balancers meets error: %s", err.Error())
-			return err
+			errs = append(errs, fmt.Errorf("delete load balancers: %w", err))
 		}
 
-		// Delete leak security groups
-		err = vpc.DeleteVPCSecurityGroups(false)
-		if err != nil {
+		if err := vpc.DeleteVPCSecurityGroups(false); err != nil {
 			log.LogError("Delete vpc security groups meets error: %s", err.Error())
-			return err
+			errs = append(errs, fmt.Errorf("delete security groups: %w", err))
 		}
 	}
-	err = vpc.DeleteVPCNetworkInterfaces()
-	if err != nil {
+
+	if err := vpc.DeleteVPCNetworkInterfaces(); err != nil {
 		log.LogError("Delete vpc network interfaces meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete network interfaces: %w", err))
 	}
 
-	err = vpc.DeleteVPCInternetGateWays()
-	if err != nil {
-		log.LogError("Delete vpc internet gatways meets error: %s", err.Error())
-		return err
+	if err := vpc.DeleteVPCInternetGateWays(); err != nil {
+		log.LogError("Delete vpc internet gateways meets error: %s", err.Error())
+		errs = append(errs, fmt.Errorf("delete internet gateways: %w", err))
 	}
 
-	err = vpc.DeleteVPCSubnets()
-	if err != nil {
+	if err := vpc.DeleteVPCSubnets(); err != nil {
 		log.LogError("Delete vpc subnets meets error: %s", err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete subnets: %w", err))
 	}
 
-	_, err = vpc.AWSClient.DeleteVpc(vpc.VpcID)
-	if err != nil {
+	if _, err := vpc.AWSClient.DeleteVpc(vpc.VpcID); err != nil {
 		log.LogError("Delete vpc %s meets error: %s", vpc.VpcID, err.Error())
-		return err
+		errs = append(errs, fmt.Errorf("delete vpc: %w", err))
 	}
-	return nil
+
+	return errors.Join(errs...)
 }
 
 // PrepareVPC will find a vpc named <vpcName>


### PR DESCRIPTION
## Summary

Fixes three bugs in VPC resource cleanup that caused orphaned AWS resources (EIPs, NAT gateways, ENIs, VPCs) in FVT test accounts:

- **EIP leak**: `DeleteVPCNatGateways` used a single `allocationId` variable overwritten in a loop over NAT gateways. Multi-AZ VPCs have one NAT gateway per AZ, each with its own EIP, but only the last allocation ID was released. All other EIPs were orphaned.
- **Early-return on error**: `DeleteVPCChain` returned immediately on any error, skipping all subsequent cleanup steps. Changed to accumulate errors with `errors.Join` so all cleanup steps are attempted.
- **ENI detach**: `DeleteVPCNetworkInterfaces` did not detach attached ENIs before deletion. Added explicit detach with force flag and continue-on-error.

## Test plan

- [x] `go build ./pkg/...` passes
- [x] `go test ./pkg/test/vpc_client/...` passes
- [x] `gofmt` clean
- [ ] Verify in FVT environment that multi-AZ VPC cleanup releases all EIPs

Jira: https://redhat.atlassian.net/browse/ROSAENG-60102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detaching network interfaces from EC2 instances.

* **Bug Fixes**
  * Improved VPC cleanup to be best-effort: deletion/detachment steps now continue after failures and return a combined error report.
  * Enhanced NAT gateway and network interface cleanup to aggregate all encountered errors for more complete visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->