### PR TITLE
ROSAENG-59872 | fix: CreateClusterByYAMLProfile failing due to missin…

### DIFF
--- a/pkg/aws/aws_client/instance.go
+++ b/pkg/aws/aws_client/instance.go
@@ -2,7 +2,6 @@ package aws_client
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -39,7 +38,7 @@ func (client *AWSClient) LaunchInstance(subnetID string, imageID string, count i
 		log.LogInfo("Waiting for below instances ready: %s", strings.Join(instanceIDs, "，"))
 		// Wait 2 seconds for the asynchronous bastion instance to be created
 		time.Sleep(2 * time.Second)
-		_, err = client.WaitForInstancesRunning(instanceIDs, 10)
+		_, err = client.WaitForInstancesRunning(context.TODO(), instanceIDs, 10)
 		if err != nil {
 			log.LogError("Error happened for instance running: %s", err)
 		} else {
@@ -80,85 +79,51 @@ func (client *AWSClient) ListInstances(instanceIDs []string, filters ...map[stri
 	return instances, err
 }
 
-func (client *AWSClient) WaitForInstanceReady(instanceID string, timeout time.Duration) error {
-	instanceIDs := []string{
-		instanceID,
-	}
-	log.LogInfo("Waiting for below instances ready: %s ", strings.Join(instanceIDs, "|"))
-	time.Sleep(2 * time.Second)
-	_, err := client.WaitForInstancesRunning(instanceIDs, 10)
+func (client *AWSClient) WaitForInstanceReady(ctx context.Context, instanceID string, timeout time.Duration) error {
+	log.LogInfo("Waiting for instance ready: %s", instanceID)
+	_, err := client.WaitForInstancesRunning(ctx, []string{instanceID}, timeout)
 	return err
 }
 
-func (client *AWSClient) CheckInstanceState(instanceIDs ...string) (*ec2.DescribeInstanceStatusOutput, error) {
+func (client *AWSClient) CheckInstanceState(ctx context.Context, instanceIDs ...string) (*ec2.DescribeInstanceStatusOutput, error) {
 	log.LogInfo("Check instances status of %s", strings.Join(instanceIDs, ","))
 	includeAll := true
 	input := &ec2.DescribeInstanceStatusInput{
 		InstanceIds:         instanceIDs,
 		IncludeAllInstances: &includeAll,
 	}
-	output, err := client.Ec2Client.DescribeInstanceStatus(context.TODO(), input)
+	output, err := client.Ec2Client.DescribeInstanceStatus(ctx, input)
 	return output, err
 }
 
-// timeout indicates the minutes
-func (client *AWSClient) WaitForInstancesRunning(instanceIDs []string, timeout time.Duration) (allRunning bool, err error) {
-	startTime := time.Now()
-
-	for time.Now().Before(startTime.Add(timeout * time.Minute)) {
-		allRunning = true
-		output, err := client.CheckInstanceState(instanceIDs...)
-		if err != nil {
-			log.LogError("Error happened when describe instant status: %s", strings.Join(instanceIDs, ","))
-			return false, err
-		}
-		if len(output.InstanceStatuses) == 0 {
-			log.LogWarning("Instance status description for %s is 0", strings.Join(instanceIDs, ","))
-		}
-		for _, ins := range output.InstanceStatuses {
-			log.LogInfo("Instance ID %s is in status of %s", *ins.InstanceId, ins.InstanceStatus.Status)
-			log.LogInfo("Instance ID %s is in state of %s", *ins.InstanceId, ins.InstanceState.Name)
-			if ins.InstanceState.Name != types.InstanceStateNameRunning && ins.InstanceStatus.Status != types.SummaryStatusOk {
-				allRunning = false
-			}
-
-		}
-		if allRunning {
-			return true, nil
-		}
-		time.Sleep(time.Minute)
+// WaitForInstancesRunning uses the EC2 InstanceStatusOk waiter to block until
+// all instances have InstanceState=running and both status checks pass (ok).
+// This is stricter than InstanceRunningWaiter and ensures SSH is reachable.
+// timeout is in minutes.
+func (client *AWSClient) WaitForInstancesRunning(ctx context.Context, instanceIDs []string, timeout time.Duration) (bool, error) {
+	log.LogInfo("Waiting for instances to reach running+ok status: %s", strings.Join(instanceIDs, ","))
+	waiter := ec2.NewInstanceStatusOkWaiter(client.Ec2Client)
+	err := waiter.Wait(ctx, &ec2.DescribeInstanceStatusInput{
+		InstanceIds: instanceIDs,
+	}, timeout*time.Minute)
+	if err != nil {
+		return false, err
 	}
-	err = fmt.Errorf("timeout for waiting instances running")
-	return
+	return true, nil
 }
-func (client *AWSClient) WaitForInstancesTerminated(instanceIDs []string, timeout time.Duration) (allTerminated bool, err error) {
-	startTime := time.Now()
-	for time.Now().Before(startTime.Add(timeout * time.Minute)) {
-		allTerminated = true
-		output, err := client.CheckInstanceState(instanceIDs...)
-		if err != nil {
-			log.LogError("Error happened when describe instant status: %s", strings.Join(instanceIDs, ","))
-			return false, err
-		}
-		if len(output.InstanceStatuses) == 0 {
-			log.LogWarning("Instance status description for %s is 0", strings.Join(instanceIDs, ","))
-		}
-		for _, ins := range output.InstanceStatuses {
-			log.LogInfo("Instance ID %s is in status of %s", *ins.InstanceId, ins.InstanceStatus.Status)
-			log.LogInfo("Instance ID %s is in state of %s", *ins.InstanceId, ins.InstanceState.Name)
-			if ins.InstanceState.Name != types.InstanceStateNameTerminated {
-				allTerminated = false
-			}
 
-		}
-		if allTerminated {
-			return true, nil
-		}
-		time.Sleep(time.Minute)
+// WaitForInstancesTerminated uses the EC2 InstanceTerminated waiter to block
+// until all instances reach the terminated state. timeout is in minutes.
+func (client *AWSClient) WaitForInstancesTerminated(ctx context.Context, instanceIDs []string, timeout time.Duration) (bool, error) {
+	log.LogInfo("Waiting for instances to be terminated: %s", strings.Join(instanceIDs, ","))
+	waiter := ec2.NewInstanceTerminatedWaiter(client.Ec2Client)
+	err := waiter.Wait(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: instanceIDs,
+	}, timeout*time.Minute)
+	if err != nil {
+		return false, err
 	}
-	err = fmt.Errorf("timeout for waiting instances terminated")
-	return
-
+	return true, nil
 }
 
 // Search instance types for specified region/availability zones
@@ -235,7 +200,7 @@ func (client *AWSClient) TerminateInstances(instanceIDs []string, wait bool, tim
 		log.LogInfo("Terminate instances %s successfully", strings.Join(instanceIDs, ","))
 	}
 	if wait {
-		err = client.WaitForInstanceTerminated(instanceIDs, timeout)
+		err = client.WaitForInstanceTerminated(context.TODO(), instanceIDs, timeout)
 		if err != nil {
 			log.LogError("Waiting for  instances %s termination timeout %s ", strings.Join(instanceIDs, ","), err)
 			return err
@@ -245,9 +210,9 @@ func (client *AWSClient) TerminateInstances(instanceIDs []string, wait bool, tim
 	return nil
 }
 
-func (client *AWSClient) WaitForInstanceTerminated(instanceIDs []string, timeout time.Duration) error {
+func (client *AWSClient) WaitForInstanceTerminated(ctx context.Context, instanceIDs []string, timeout time.Duration) error {
 	log.LogInfo("Waiting for below instances terminated: %s ", strings.Join(instanceIDs, ","))
-	_, err := client.WaitForInstancesTerminated(instanceIDs, timeout)
+	_, err := client.WaitForInstancesTerminated(ctx, instanceIDs, timeout)
 	return err
 }
 

--- a/pkg/aws/aws_client/instance_test.go
+++ b/pkg/aws/aws_client/instance_test.go
@@ -1,0 +1,139 @@
+package aws_client_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	. "github.com/openshift-online/ocm-common/pkg/aws/aws_client"
+)
+
+var _ = Describe("WaitForInstancesRunning", func() {
+	var (
+		mockCtrl      *gomock.Controller
+		mockEC2Client *MockEC2ClientAPI
+		client        *AWSClient
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockEC2Client = NewMockEC2ClientAPI(mockCtrl)
+		client = &AWSClient{Ec2Client: mockEC2Client}
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("returns true when the SDK waiter reports all instances are status-ok", func() {
+		instanceID := "i-0abc123"
+
+		// The InstanceStatusOkWaiter calls DescribeInstanceStatus until
+		// all instances have InstanceStatus.Status == ok.
+		// The SDK waiter injects an extra option function (3rd variadic arg).
+		mockEC2Client.EXPECT().
+			DescribeInstanceStatus(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []types.InstanceStatus{
+					{
+						InstanceId:     aws.String(instanceID),
+						InstanceState:  &types.InstanceState{Name: types.InstanceStateNameRunning},
+						InstanceStatus: &types.InstanceStatusSummary{Status: types.SummaryStatusOk},
+						SystemStatus:   &types.InstanceStatusSummary{Status: types.SummaryStatusOk},
+					},
+				},
+			}, nil).
+			AnyTimes()
+
+		allRunning, err := client.WaitForInstancesRunning(ctx, []string{instanceID}, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allRunning).To(BeTrue())
+	})
+
+	It("propagates errors returned by the SDK waiter", func() {
+		// Use a short deadline so the waiter gives up after the first failed
+		// call instead of retrying for the full timeout duration.
+		shortCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		mockEC2Client.EXPECT().
+			DescribeInstanceStatus(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("api error: request throttled")).
+			AnyTimes()
+
+		allRunning, err := client.WaitForInstancesRunning(shortCtx, []string{"i-0abc123"}, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(allRunning).To(BeFalse())
+	})
+})
+
+var _ = Describe("WaitForInstancesTerminated", func() {
+	var (
+		mockCtrl      *gomock.Controller
+		mockEC2Client *MockEC2ClientAPI
+		client        *AWSClient
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockEC2Client = NewMockEC2ClientAPI(mockCtrl)
+		client = &AWSClient{Ec2Client: mockEC2Client}
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("returns true when the SDK waiter reports all instances are terminated", func() {
+		instanceID := "i-dead"
+
+		// The InstanceTerminatedWaiter calls DescribeInstances until
+		// all instances have State.Name == terminated.
+		// The SDK waiter injects an extra option function (3rd variadic arg).
+		mockEC2Client.EXPECT().
+			DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{
+						Instances: []types.Instance{
+							{
+								InstanceId: aws.String(instanceID),
+								State:      &types.InstanceState{Name: types.InstanceStateNameTerminated},
+							},
+						},
+					},
+				},
+			}, nil).
+			AnyTimes()
+
+		allTerminated, err := client.WaitForInstancesTerminated(ctx, []string{instanceID}, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allTerminated).To(BeTrue())
+	})
+
+	It("propagates errors returned by the SDK waiter", func() {
+		// Use a short deadline so the waiter gives up quickly.
+		shortCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		mockEC2Client.EXPECT().
+			DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("api error: unauthorized")).
+			AnyTimes()
+
+		allTerminated, err := client.WaitForInstancesTerminated(shortCtx, []string{"i-dead"}, 10)
+		Expect(err).To(HaveOccurred())
+		Expect(allTerminated).To(BeFalse())
+	})
+})

--- a/pkg/test/vpc_client/export_test.go
+++ b/pkg/test/vpc_client/export_test.go
@@ -1,0 +1,10 @@
+package vpc_client
+
+// Export internal vars for testing only.
+// This file is compiled exclusively as part of the test binary.
+
+var (
+	SSHMaxAttempts   = &sshMaxAttempts
+	SSHRetryInterval = &sshRetryInterval
+	SSHDialTimeout   = &sshDialTimeout
+)

--- a/pkg/test/vpc_client/proxy.go
+++ b/pkg/test/vpc_client/proxy.go
@@ -1,9 +1,10 @@
 package vpc_client
 
 import (
+	"context"
 	"fmt"
 	"regexp"
-	"time"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
@@ -12,6 +13,37 @@ import (
 	"github.com/openshift-online/ocm-common/pkg/log"
 	"github.com/openshift-online/ocm-common/pkg/utils"
 )
+
+// proxyInstanceReadyTimeoutMinutes is the maximum time to wait for a proxy
+// EC2 instance to pass its status checks before attempting SSH setup.
+const proxyInstanceReadyTimeoutMinutes = 10
+
+// namedCmd pairs a shell command with a safe description for logging.
+// When logLabel is set it is logged instead of the raw command, preventing
+// sensitive values (e.g. credentials) from appearing in log output.
+type namedCmd struct {
+	cmd      string
+	logLabel string
+}
+
+func (c namedCmd) safeLabel() string {
+	if c.logLabel != "" {
+		return c.logLabel
+	}
+	return c.cmd
+}
+
+// validateProxyCredential rejects values that contain characters capable of
+// escaping a Python double-quoted string literal. Only letters, digits,
+// hyphens, underscores, and dots are allowed.
+func validateProxyCredential(fieldName, value string) error {
+	for _, r := range value {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' && r != '.' {
+			return fmt.Errorf("proxy %s contains invalid character %q: only letters, digits, hyphens, underscores, and dots are allowed", fieldName, r)
+		}
+	}
+	return nil
+}
 
 /*
 MITM Proxy Authentication Support
@@ -168,7 +200,12 @@ func (vpc *VPC) LaunchProxyInstanceWithAuth(zone string, keypairName string, pri
 	}
 	log.LogInfo("Prepare EIP successfully for the proxy preparation. Launch with IP: %s", publicIP)
 
-	time.Sleep(2 * time.Minute)
+	log.LogInfo("Waiting for proxy instance %s to pass EC2 status checks before attempting SSH...", instID)
+	if _, err = vpc.AWSClient.WaitForInstancesRunning(context.Background(), []string{instID}, proxyInstanceReadyTimeoutMinutes); err != nil {
+		log.LogError("Proxy instance %s did not become ready within timeout: %s", instID, err)
+		return inst, "", "", err
+	}
+
 	hostname := fmt.Sprintf("%s:22", publicIP)
 	err = setupMITMProxyServer(sshKey, hostname, username, password)
 	if err != nil {
@@ -186,16 +223,27 @@ func (vpc *VPC) LaunchProxyInstanceWithAuth(zone string, keypairName string, pri
 }
 
 func setupMITMProxyServer(sshKey string, hostname string, username string, password string) (err error) {
-	setupProxyCMDs := []string{
-		"sudo yum install -y wget",
-		"wget https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz",
-		"mkdir mitm",
-		"tar zxvf mitmproxy-7.0.2-linux.tar.gz -C mitm",
+	cmds := []namedCmd{
+		{cmd: "sudo yum install -y wget"},
+		{cmd: "wget https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz"},
+		{cmd: "mkdir mitm"},
+		{cmd: "tar zxvf mitmproxy-7.0.2-linux.tar.gz -C mitm"},
 	}
 
-	// If username and password are provided, set up authentication
+	// Reject partial credentials: supplying only one would silently launch an
+	// unauthenticated proxy, which is never the intended behaviour.
+	if (username == "") != (password == "") {
+		return fmt.Errorf("proxy credentials must be provided together: username provided=%t password provided=%t",
+			username != "", password != "")
+	}
+
 	if username != "" && password != "" {
-		// Create a simple authentication script
+		if err := validateProxyCredential("username", username); err != nil {
+			return err
+		}
+		if err := validateProxyCredential("password", password); err != nil {
+			return err
+		}
 		authScript := fmt.Sprintf(`cat > ~/proxy_auth.py << 'EOF'
 import mitmproxy.http
 import mitmproxy.addons.core
@@ -220,24 +268,27 @@ addons = [
 ]
 EOF`, username, password)
 
-		setupProxyCMDs = append(setupProxyCMDs, authScript)
-		setupProxyCMDs = append(setupProxyCMDs,
-			"nohup ./mitm/mitmdump --showhost --ssl-insecure --script ~/proxy_auth.py > mitm.log 2>&1 &")
+		cmds = append(cmds,
+			namedCmd{cmd: authScript, logLabel: "[proxy auth configuration — redacted]"},
+			namedCmd{cmd: "nohup ./mitm/mitmdump --showhost --ssl-insecure --script ~/proxy_auth.py > mitm.log 2>&1 &"},
+		)
 	} else {
-		// No authentication - use standard setup
-		setupProxyCMDs = append(setupProxyCMDs,
-			"nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &")
+		cmds = append(cmds,
+			namedCmd{cmd: "nohup ./mitm/mitmdump --showhost --ssl-insecure > mitm.log 2>&1 &"},
+		)
 	}
 
-	setupProxyCMDs = append(setupProxyCMDs, "sleep 5")
-	setupProxyCMDs = append(setupProxyCMDs, "http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem")
+	cmds = append(cmds,
+		namedCmd{cmd: "sleep 5"},
+		namedCmd{cmd: "http_proxy=127.0.0.1:8080 curl http://mitm.it/cert/pem -s > ~/mitm-ca.pem"},
+	)
 
-	for _, cmd := range setupProxyCMDs {
-		_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, cmd)
+	for _, c := range cmds {
+		_, err = Exec_CMD(CON.AWSInstanceUser, sshKey, hostname, c.cmd)
 		if err != nil {
 			return err
 		}
-		log.LogDebug("Run the cmd successfully: %s", cmd)
+		log.LogDebug("Run the cmd successfully: %s", c.safeLabel())
 	}
 	return
 }

--- a/pkg/test/vpc_client/ssh.go
+++ b/pkg/test/vpc_client/ssh.go
@@ -2,12 +2,27 @@ package vpc_client
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
+	"github.com/openshift-online/ocm-common/pkg/log"
 	sshclient "golang.org/x/crypto/ssh"
 )
 
+// These are vars (not consts) so that tests can override them to avoid long sleeps.
+var (
+	sshMaxAttempts   = 5
+	sshRetryInterval = 30 * time.Second
+	sshDialTimeout   = 30 * time.Second
+)
+
+// Exec_CMD runs a command on a remote host over SSH.
+// It retries up to sshMaxAttempts times with sshRetryInterval backoff to handle
+// transient connection errors that occur while an instance is still initializing.
+// Errors from the remote command itself (non-zero exit) are not retried.
 func Exec_CMD(userName, keyPath string, addr string, cmd string) (result string, err error) {
 	authMethod, err := publicKeyAuthFunc(keyPath)
 	if err != nil {
@@ -19,41 +34,70 @@ func Exec_CMD(userName, keyPath string, addr string, cmd string) (result string,
 			authMethod,
 		},
 		HostKeyCallback: sshclient.InsecureIgnoreHostKey(),
+		Timeout:         sshDialTimeout,
 	}
 
+	for attempt := 1; attempt <= sshMaxAttempts; attempt++ {
+		result, err = execSSHCommand(config, addr, cmd)
+		if err == nil {
+			return result, nil
+		}
+		// A remote command ran but exited non-zero — this is not a transient
+		// connection problem, so retrying would just re-run the command.
+		if isSSHExitError(err) {
+			return "", err
+		}
+		if attempt < sshMaxAttempts {
+			log.LogWarning("SSH attempt %d/%d failed for %s: %s. Retrying in %s...",
+				attempt, sshMaxAttempts, addr, err, sshRetryInterval)
+			time.Sleep(sshRetryInterval)
+		}
+	}
+	return "", fmt.Errorf("SSH command failed after %d attempts: %w", sshMaxAttempts, err)
+}
+
+func execSSHCommand(config *sshclient.ClientConfig, addr string, cmd string) (string, error) {
 	client, err := sshclient.Dial("tcp", addr, config)
 	if err != nil {
-		err = fmt.Errorf("failed to dail %s", err)
-		return "", err
+		return "", fmt.Errorf("failed to dial %s: %w", addr, err)
 	}
 	defer client.Close()
+
 	session, err := client.NewSession()
 	if err != nil {
-		err = fmt.Errorf("failed to create session %s", err)
-		return "", err
+		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
-	var b bytes.Buffer
-	session.Stdout = &b
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
 
 	if err := session.Run(cmd); err != nil {
-		err = fmt.Errorf("failed to run command %s", err)
-		return "", err
+		stderrStr := strings.TrimSpace(stderr.String())
+		if stderrStr != "" {
+			return "", fmt.Errorf("failed to run command (stderr: %q): %w", stderrStr, err)
+		}
+		return "", fmt.Errorf("failed to run command: %w", err)
 	}
-	return b.String(), nil
+	return stdout.String(), nil
+}
+
+// isSSHExitError reports whether err (possibly wrapped) is an SSH remote
+// command exit error. These are not transient and should not be retried.
+func isSSHExitError(err error) bool {
+	var exitErr *sshclient.ExitError
+	return errors.As(err, &exitErr)
 }
 
 func publicKeyAuthFunc(keyPath string) (sshclient.AuthMethod, error) {
 	key, err := os.ReadFile(keyPath)
 	if err != nil {
-		err = fmt.Errorf("ssh key file read failed %s", err)
-		return nil, err
+		return nil, fmt.Errorf("ssh key file read failed: %w", err)
 	}
 	signer, err := sshclient.ParsePrivateKey(key)
 	if err != nil {
-		err = fmt.Errorf("ssh key sinher failed %s", err)
-		return nil, err
+		return nil, fmt.Errorf("ssh key signer failed: %w", err)
 	}
 	return sshclient.PublicKeys(signer), nil
 }

--- a/pkg/test/vpc_client/ssh_test.go
+++ b/pkg/test/vpc_client/ssh_test.go
@@ -1,0 +1,155 @@
+package vpc_client
+
+// Internal test package so we can override the unexported retry vars
+// (sshMaxAttempts, sshRetryInterval, sshDialTimeout) without export_test.go.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/ssh"
+)
+
+// writeTempEd25519Key generates an Ed25519 key (microseconds vs ~100ms for RSA)
+// and writes it to a temp file in OpenSSH PEM format.
+// The caller is responsible for removing the file.
+func writeTempEd25519Key() (path string, err error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", err
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp("", "ocm-test-key-*.pem")
+	if err != nil {
+		return "", err
+	}
+	if err := pem.Encode(f, block); err != nil {
+		f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// rejectingListener starts a TCP listener that accepts every connection and
+// immediately closes it, simulating a host whose SSH daemon is not yet ready.
+// It increments *count on each accepted connection.
+func rejectingListener(count *int32) (net.Listener, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			atomic.AddInt32(count, 1)
+			conn.Close()
+		}
+	}()
+	return ln, nil
+}
+
+var _ = Describe("Exec_CMD SSH retry", func() {
+	var (
+		keyFile          string
+		savedMaxAttempts int
+		savedRetryIvl    time.Duration
+		savedDialTimeout time.Duration
+	)
+
+	BeforeEach(func() {
+		var err error
+		keyFile, err = writeTempEd25519Key()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Save originals and install fast values so tests complete in milliseconds.
+		savedMaxAttempts = sshMaxAttempts
+		savedRetryIvl = sshRetryInterval
+		savedDialTimeout = sshDialTimeout
+
+		sshRetryInterval = 0
+		sshDialTimeout = 2 * time.Second
+	})
+
+	AfterEach(func() {
+		os.Remove(keyFile)
+		sshMaxAttempts = savedMaxAttempts
+		sshRetryInterval = savedRetryIvl
+		sshDialTimeout = savedDialTimeout
+	})
+
+	It("retries exactly sshMaxAttempts times when the server rejects every connection", func() {
+		sshMaxAttempts = 3
+		var dialCount int32
+
+		ln, err := rejectingListener(&dialCount)
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+
+		_, err = Exec_CMD("testuser", keyFile, ln.Addr().String(), "echo hello")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("3 attempts"))
+
+		Eventually(func() int32 { return atomic.LoadInt32(&dialCount) }, "2s", "50ms").
+			Should(BeEquivalentTo(3))
+	})
+
+	It("returns immediately when no server is listening (connection refused)", func() {
+		sshMaxAttempts = 2
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		addr := ln.Addr().String()
+		ln.Close()
+
+		start := time.Now()
+		_, err = Exec_CMD("testuser", keyFile, addr, "echo hello")
+		Expect(err).To(HaveOccurred())
+		Expect(time.Since(start)).To(BeNumerically("<", 10*time.Second))
+	})
+
+	It("wraps the original dial failure in the returned error", func() {
+		sshMaxAttempts = 1
+
+		ln, err := rejectingListener(new(int32))
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+
+		_, err = Exec_CMD("testuser", keyFile, ln.Addr().String(), "echo hello")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to dial"))
+	})
+})
+
+var _ = Describe("isSSHExitError", func() {
+	It("returns false for a plain connection error", func() {
+		Expect(isSSHExitError(fmt.Errorf("connection refused"))).To(BeFalse())
+	})
+
+	It("returns true for an ssh.ExitError", func() {
+		exitErr := &ssh.ExitError{Waitmsg: ssh.Waitmsg{}}
+		Expect(isSSHExitError(exitErr)).To(BeTrue())
+	})
+
+	It("returns true for a wrapped ssh.ExitError", func() {
+		exitErr := &ssh.ExitError{Waitmsg: ssh.Waitmsg{}}
+		wrapped := fmt.Errorf("failed to run command: %w", exitErr)
+		Expect(isSSHExitError(wrapped)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/ROSAENG-59872

Fixed the ssh issue by adding fix 1 ssh retry and fix 2 Replace hardcoded sleep with EC2 status check.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD or tooling change

## Testing

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Instance launch/termination waiting now uses EC2 waiter-based health checks (with context-aware timeouts) instead of fixed polling/sleeps.
  * Test VPC proxy instance launch now waits for EC2 readiness rather than using a fixed delay.

* **New Features**
  * SSH command execution now uses a configurable timeout and a bounded retry loop, avoiding retries for remote command exit failures.

* **Tests**
  * Added Ginkgo/Gomega coverage for instance running/terminated waiters and SSH retry/remote exit-error detection.

* **Chores**
  * Hardened MITM proxy authentication with stricter credential validation and safer redacted logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->