### PR TITLE
ROSAENG-60358 | fix: catch the notfound errors and ignore them in deletevpc flow

### DIFF
--- a/pkg/aws/errors/errors.go
+++ b/pkg/aws/errors/errors.go
@@ -30,6 +30,7 @@ const (
 	DependencyViolation          = "DependencyViolation"
 	NoSuchEntity                 = "NoSuchEntity"
 	InvalidRouteTableID          = "InvalidRouteTableID.NotFound"
+	InvalidAssociationID         = "InvalidAssociationID.NotFound"
 	InvalidInternetGatewayID     = "InvalidInternetGatewayID.NotFound"
 	InvalidVpcID                 = "InvalidVpcID.NotFound"
 	InvalidAllocationID          = "InvalidAllocationID.NotFound"

--- a/pkg/test/vpc_client/internet_gateway.go
+++ b/pkg/test/vpc_client/internet_gateway.go
@@ -1,5 +1,9 @@
 package vpc_client
 
+import (
+	awserrors "github.com/openshift-online/ocm-common/pkg/aws/errors"
+)
+
 // PrepareInternetGateway will return the existing internet gateway if there is one attached to the vpc
 // Otherwise, it will create a new one and attach to the VPC
 func (vpc *VPC) PrepareInternetGateway() (igwID string, err error) {
@@ -29,11 +33,17 @@ func (vpc *VPC) DeleteVPCInternetGateWays() error {
 	for _, igw := range igws {
 		_, err = vpc.AWSClient.DetachInternetGateway(*igw.InternetGatewayId, vpc.VpcID)
 		if err != nil {
-			return err
+			if !awserrors.IsErrorCode(err, awserrors.InvalidInternetGatewayID) {
+				return err
+			} else {
+				continue
+			}
 		}
 		_, err = vpc.AWSClient.DeleteInternetGateway(*igw.InternetGatewayId)
 		if err != nil {
-			return err
+			if !awserrors.IsErrorCode(err, awserrors.InvalidInternetGatewayID) {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/test/vpc_client/nat_gateway.go
+++ b/pkg/test/vpc_client/nat_gateway.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	awserrors "github.com/openshift-online/ocm-common/pkg/aws/errors"
 	"github.com/openshift-online/ocm-common/pkg/log"
 )
 
@@ -43,7 +44,8 @@ func (vpc *VPC) DeleteVPCNatGateways(vpcID string) error {
 	var releaseErrs []error
 	for _, allocID := range allocationIDs {
 		log.LogInfo("Releasing EIP allocation %s", allocID)
-		if err := vpc.AWSClient.ReleaseAddressWithAllocationID(allocID); err != nil {
+		err := vpc.AWSClient.ReleaseAddressWithAllocationID(allocID)
+		if err != nil && !awserrors.IsErrorCode(err, awserrors.InvalidAllocationID) {
 			releaseErrs = append(releaseErrs, err)
 		}
 	}

--- a/pkg/test/vpc_client/route_table.go
+++ b/pkg/test/vpc_client/route_table.go
@@ -1,5 +1,9 @@
 package vpc_client
 
+import (
+	awserrors "github.com/openshift-online/ocm-common/pkg/aws/errors"
+)
+
 func (vpc *VPC) DescribeSubnetRTMappings(subnets ...*Subnet) error {
 	rts, err := vpc.AWSClient.ListCustomerRouteTables(vpc.VpcID)
 	if err != nil {
@@ -21,12 +25,12 @@ func (vpc *VPC) DeleteVPCRouteTables(vpcID string) error {
 	for _, rt := range rts {
 		for _, asso := range rt.Associations {
 			_, err = vpc.AWSClient.DisassociateRouteTableAssociation(*asso.RouteTableAssociationId)
-			if err != nil {
+			if err != nil && !awserrors.IsErrorCode(err, awserrors.InvalidAssociationID) {
 				return err
 			}
 		}
 		err = vpc.AWSClient.DeleteRouteTable(*rt.RouteTableId)
-		if err != nil {
+		if err != nil && !awserrors.IsErrorCode(err, awserrors.InvalidRouteTableID) {
 			return err
 		}
 	}


### PR DESCRIPTION
## Description

<!-- Briefly describe the change and its motivation. -->

Fix VPC cleanup failures when AWS auto-deletes resources during cascade deletion. Updated NAT gateway, Internet gateway, and Route table cleanup functions to treat NotFound errors as success instead of failure. 
  For example, when deleting a NAT gateway, AWS automatically releases the associated Elastic IP - attempting to release it again now succeeds gracefully instead of failing. Added `InvalidAssociationID` error   
  constant to support proper error checking.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPC resource cleanup reliability. Internet gateway, NAT gateway, and route table operations now gracefully handle scenarios where resources have already been removed or disassociated. These changes prevent cleanup failures in edge cases, enhancing the robustness and resilience of infrastructure teardown workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->